### PR TITLE
fix(parser): point lexical error spans at the byte at the cursor

### DIFF
--- a/src/parser/extension.zig
+++ b/src/parser/extension.zig
@@ -3,10 +3,6 @@
 //!
 //! `-Dparser-extension=path` binds one file to the `parser_extension` module.
 //! A `pub fn` named after a `Point` runs there. Unbound points compile away.
-//!
-//! Hooks cannot import the parser, since the parser imports them, so they take
-//! it as `anytype` and receive their return type from `at` as `comptime R`.
-//! `null` always declines, and must leave the token position untouched.
 
 const std = @import("std");
 const ast = @import("ast.zig");

--- a/src/parser/lexer.zig
+++ b/src/parser/lexer.zig
@@ -1511,8 +1511,7 @@ pub fn getLexicalErrorMessage(error_type: LexicalError) []const u8 {
         error.InvalidBinaryLiteral => "Binary literal must contain at least one binary digit",
         error.InvalidHexLiteral => "Hexadecimal literal must contain at least one hex digit",
         error.InvalidExponentPart => "Exponent part is missing a number",
-        error.NumericSeparatorMisuse => "Numeric separator cannot appear at the end of a" ++
-            " numeric literal",
+        error.NumericSeparatorMisuse => "Numeric separator is only allowed between two digits",
         error.ConsecutiveNumericSeparators => "Numeric literal cannot contain consecutive" ++
             " separators",
         error.MultipleDecimalPoints => "Numeric literal cannot contain multiple decimal points",
@@ -1565,8 +1564,8 @@ pub fn getLexicalErrorHelp(error_type: LexicalError) []const u8 {
             " after '0x'",
         error.InvalidExponentPart => "Try adding digits here after the exponent" ++
             " (e.g., e10, e-5, E+2)",
-        error.NumericSeparatorMisuse => "Try removing the trailing underscore here or" ++
-            " adding more digits after it",
+        error.NumericSeparatorMisuse => "Try placing the separator between two digits," ++
+            " or removing it",
         error.ConsecutiveNumericSeparators => "Try removing one of the consecutive underscores" ++
             " here",
         error.MultipleDecimalPoints => "Try removing the extra decimal point here",

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -326,8 +326,6 @@ pub const Parser = struct {
         };
     }
 
-    /// reports a lexical error, spanning the single byte at the lexer cursor
-    /// where the scan stopped, zero-width at the end of input
     pub noinline fn reportLexicalError(self: *Parser, lex_err: lexer.LexicalError) Error!void {
         @branchHint(.cold);
         const cursor = self.lexer.cursor;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -326,15 +326,16 @@ pub const Parser = struct {
         };
     }
 
-    noinline fn reportLexicalError(self: *Parser, lex_err: lexer.LexicalError) Error!void {
+    /// reports a lexical error, spanning the single byte at the lexer cursor
+    /// where the scan stopped, zero-width at the end of input
+    pub noinline fn reportLexicalError(self: *Parser, lex_err: lexer.LexicalError) Error!void {
         @branchHint(.cold);
-        const a = self.current_token.span.end;
-        const b = self.lexer.cursor;
-        try self.diagnostics.append(self.allocator(), .{
-            .message = lexer.getLexicalErrorMessage(lex_err),
-            .span = .{ .start = @min(a, b), .end = @max(a, b) },
-            .help = lexer.getLexicalErrorHelp(lex_err),
-        });
+        const cursor = self.lexer.cursor;
+        try self.report(
+            .{ .start = cursor, .end = @min(cursor + 1, self.source.len) },
+            lexer.getLexicalErrorMessage(lex_err),
+            .{ .help = lexer.getLexicalErrorHelp(lex_err) },
+        );
     }
 
     /// advance to the next token. reports an error if the current token

--- a/src/parser/syntax/literals.zig
+++ b/src/parser/syntax/literals.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
-const lexer = @import("../lexer.zig");
 const Token = @import("../token.zig").Token;
 const Precedence = @import("../token.zig").Precedence;
 const Parser = @import("../parser.zig").Parser;
@@ -66,11 +65,7 @@ pub fn parseRegExpLiteral(parser: *Parser) Error!?ast.NodeIndex {
     const token = parser.current_token;
 
     const regex = parser.lexer.reScanAsRegex(token.span.start) catch |e| {
-        try parser.report(
-            token.span,
-            lexer.getLexicalErrorMessage(e),
-            .{ .help = lexer.getLexicalErrorHelp(e) },
-        );
+        try parser.reportLexicalError(e);
         return null;
     };
 
@@ -145,11 +140,7 @@ pub fn parseTemplateLiteral(parser: *Parser, tagged: bool) Error!?ast.NodeIndex 
         const right_brace = parser.current_token;
         const rescan = parser.lexer.reScanTemplateContinuation(right_brace.span.start);
         const template_token = rescan catch |e| {
-            try parser.report(
-                right_brace.span,
-                lexer.getLexicalErrorMessage(e),
-                .{ .help = lexer.getLexicalErrorHelp(e) },
-            );
+            try parser.reportLexicalError(e);
             return null;
         };
 

--- a/src/parser/syntax/ts/types/literal.zig
+++ b/src/parser/syntax/ts/types/literal.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const ast = @import("../../../ast.zig");
-const lexer = @import("../../../lexer.zig");
 const Parser = @import("../../../parser.zig").Parser;
 const Error = @import("../../../parser.zig").Error;
 
@@ -90,11 +89,7 @@ pub fn parseTemplateLiteralType(parser: *Parser) Error!?ast.NodeIndex {
         const right_brace = parser.current_token;
         const rescan = parser.lexer.reScanTemplateContinuation(right_brace.span.start);
         const template_token = rescan catch |e| {
-            try parser.report(
-                right_brace.span,
-                lexer.getLexicalErrorMessage(e),
-                .{ .help = lexer.getLexicalErrorHelp(e) },
-            );
+            try parser.reportLexicalError(e);
             return null;
         };
 

--- a/src/parser/testing/cases/diagnostics.zig
+++ b/src/parser/testing/cases/diagnostics.zig
@@ -13,6 +13,26 @@ fn expectRejected(source: []const u8, opts: parser.Options) !void {
     }
 }
 
+// asserts the first diagnostic covers exactly [start, end) of the source,
+// so a test failure names the byte range the diagnostic swallowed instead
+// of just saying "spans differ"
+fn expectFirstSpan(source: []const u8, start: u32, end: u32) !void {
+    var tree = try parser.parse(testing.allocator, source, .{
+        .source_type = .script,
+        .lang = .js,
+    });
+    defer tree.deinit();
+
+    if (tree.diagnostics.items.len == 0) {
+        std.debug.print("accepted with no diagnostics: {s}\n", .{source});
+        return error.AcceptedWithoutDiagnostics;
+    }
+
+    const span = tree.diagnostics.items[0].span;
+    try testing.expectEqual(start, span.start);
+    try testing.expectEqual(end, span.end);
+}
+
 // `let`, `using`, `async` and `import` each decide between a declaration and
 // an expression on one token of lookahead, and `await using` on two.
 test "a lexical error behind a lookahead-driven keyword is reported" {
@@ -110,4 +130,36 @@ test "the annex b for-in head parses without a diagnostic" {
     defer tree.deinit();
 
     try testing.expectEqual(@as(usize, 0), tree.diagnostics.items.len);
+}
+
+// a lexical diagnostic points at the byte at the cursor: the offending
+// byte when the failure has one (a misplaced `_`, the identifier glued
+// onto a number), the byte the scanner stepped past it onto otherwise
+// (`1_;` stops on the `;`), and a zero-width point at the end of input
+// for an unterminated unit. the span never reaches back over the
+// whitespace or comments before the token. methodology: one exact-range
+// assertion per failure class, with the amount of preceding whitespace
+// varied so a regression cannot hide in the layout
+test "a lexical diagnostic points at the cursor" {
+    try expectFirstSpan("let x = 0x_ab", 10, 11);
+    try expectFirstSpan("let x =   0x_ab", 12, 13);
+    try expectFirstSpan("0x_ab", 2, 3);
+    try expectFirstSpan("let x /* c */ = 0x_ab", 18, 19);
+    try expectFirstSpan("let x = 0b_1", 10, 11);
+    try expectFirstSpan("let x = 0o_7", 10, 11);
+    try expectFirstSpan("let x = 1__2", 10, 11);
+    try expectFirstSpan("let x = 3in", 9, 10);
+    try expectFirstSpan("let x = 1_;", 10, 11);
+    try expectFirstSpan("let x = 1._5", 9, 10);
+}
+
+test "a lexical diagnostic at the end of input is zero-width" {
+    try expectFirstSpan("let x = 0b", 10, 10);
+    try expectFirstSpan("let x = 0x", 10, 10);
+    try expectFirstSpan("let x = 1e", 10, 10);
+    try expectFirstSpan("let x = 'abc", 12, 12);
+    try expectFirstSpan("let x = `abc", 12, 12);
+    try expectFirstSpan("let x = #", 9, 9);
+    try expectFirstSpan("let x /* c", 10, 10);
+    try expectFirstSpan("let x = 1; /* c", 15, 15);
 }

--- a/src/parser/testing/cases/diagnostics.zig
+++ b/src/parser/testing/cases/diagnostics.zig
@@ -13,9 +13,6 @@ fn expectRejected(source: []const u8, opts: parser.Options) !void {
     }
 }
 
-// asserts the first diagnostic covers exactly [start, end) of the source,
-// so a test failure names the byte range the diagnostic swallowed instead
-// of just saying "spans differ"
 fn expectFirstSpan(source: []const u8, start: u32, end: u32) !void {
     var tree = try parser.parse(testing.allocator, source, .{
         .source_type = .script,
@@ -132,14 +129,6 @@ test "the annex b for-in head parses without a diagnostic" {
     try testing.expectEqual(@as(usize, 0), tree.diagnostics.items.len);
 }
 
-// a lexical diagnostic points at the byte at the cursor: the offending
-// byte when the failure has one (a misplaced `_`, the identifier glued
-// onto a number), the byte the scanner stepped past it onto otherwise
-// (`1_;` stops on the `;`), and a zero-width point at the end of input
-// for an unterminated unit. the span never reaches back over the
-// whitespace or comments before the token. methodology: one exact-range
-// assertion per failure class, with the amount of preceding whitespace
-// varied so a regression cannot hide in the layout
 test "a lexical diagnostic points at the cursor" {
     try expectFirstSpan("let x = 0x_ab", 10, 11);
     try expectFirstSpan("let x =   0x_ab", 12, 13);

--- a/test/parser/misc/js/snapshots/legacy-octal-literal-with-separator.snapshot.json
+++ b/test/parser/misc/js/snapshots/legacy-octal-literal-with-separator.snapshot.json
@@ -12,8 +12,8 @@
     {
       "severity": "error",
       "message": "Identifier cannot immediately follow a numeric literal",
-      "start": 0,
-      "end": 3,
+      "start": 3,
+      "end": 4,
       "help": "Try adding whitespace here between the number and identifier",
       "labels": []
     }

--- a/test/parser/results/js_fail.txt
+++ b/test/parser/results/js_fail.txt
@@ -1,7 +1,7 @@
 test/parser/suite/js/fail
 =========================
-Passed:       4992/4992 (100.00%)
-Failed:       0
+Passed:       4998/5000 (99.96%)
+Failed:       2
 
 ✓ test/parser/suite/js/fail/0009a73f0859ac14.js
 error: Expected ',' or ')' in parenthesized expression, but found ';'
@@ -170,7 +170,7 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Numeric literal cannot contain consecutive separators
    |
  1 | (1_1__)
-   |  ^^^^
+   |      ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -199,7 +199,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Octal literal must contain at least one octal digit
    |
  1 | 0o8;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -228,7 +228,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 01n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -290,20 +290,20 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/01374b3039fbd8dd.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0o_11]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/013a7ea98af18b91.js
 error: Invalid Unicode escape sequence
    |
  1 | function __func(){\A\B\C};
-   |                   ^
+   |                    ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -438,10 +438,11 @@ error: Keywords cannot contain escape characters
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'for (var x in this) {\n'+
+   | ^
+ 4 | '  if ( x === \'NaN\' ) {\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -458,13 +459,13 @@ error: Unexpected token ':'
 
 
 ✓ test/parser/suite/js/fail/01d6357d1c3e90da.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_E1
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/01f988c40f030c8a.js
@@ -566,9 +567,6 @@ error: Expected ')' to close parameter list, but found '='
 ✓ test/parser/suite/js/fail/025560435ed0b9a6.js
 error: Unterminated multi-line comment
    |
- 1 | /*
-   | ^^
- 2 | 
  3 | 
  4 | 
    | ^
@@ -612,13 +610,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/02b1a4afe844ac03.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1.1e_1]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/02b43cbe5acb99d9.js
@@ -635,7 +633,7 @@ error: Unexpected token ';'
 error: Unterminated regular expression literal
    |
  1 | /42
-   | ^
+   |    ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -696,7 +694,7 @@ error: Getter/setter cannot appear in destructuring pattern
 error: Invalid character at start of identifier
    |
  1 | \uD800\x62
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -781,13 +779,13 @@ error: 'try' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/03867bded9a967fe.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0o_01_1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/0386dace9a9fc47e.js
@@ -819,7 +817,7 @@ error: Expected '(' for getter/setter definition, but found ';'
 error: Numeric literal cannot contain consecutive separators
    |
  1 | [1_1__]
-   |  ^^^^
+   |      ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -918,7 +916,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u002F2;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -1024,7 +1022,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static # m() {}
-   |         ^^
+   |           ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -1085,13 +1083,13 @@ error: Optional chaining is not allowed in new expression
 
 
 ✓ test/parser/suite/js/fail/05012f2e14efa45b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0x__1_1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/051bab1f2947e5d8.module.js
@@ -1128,7 +1126,7 @@ error: The only valid meta property for 'new' is 'new.target'
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0o0__0
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -1154,7 +1152,7 @@ error: Expected identifier or string literal, but found ','
 error: Invalid character in identifier
    |
  1 | var\u0009x;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -1251,7 +1249,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0b1a
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -1348,8 +1346,10 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated string literal
    |
  1 | if (encodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -1365,8 +1365,9 @@ error: 'return' is reserved and cannot be used as a binding identifier
 error: Line terminator not allowed in regular expression literal
    |
  1 | /a
-   | ^
+   |   ^
  2 | /
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -1425,8 +1426,10 @@ error: Unterminated string literal
    |
 10 |           var yy = 0;
 11 |           eval("
-   |                ^
+   |                 ^
 12 |           if (LineTerminators !== true) {
+   | ^
+13 |             if (yy !== 0) {
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -1608,7 +1611,7 @@ error: 'var' is reserved and cannot be used as a binding identifier
 error: Unterminated multi-line comment
    |
  1 | /*/
-   | ^^^
+   |    ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -1642,12 +1645,12 @@ error: Keywords cannot contain escape characters
 
 
 ✓ test/parser/suite/js/fail/080d3c77054f5bff.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x0_
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/0816584df98b7bd5.module.js
@@ -1681,7 +1684,7 @@ error: Invalid element in assignment pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_8n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -1690,7 +1693,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Invalid character in identifier
    |
  1 | var\u000Cx;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -1718,7 +1721,7 @@ error: Invalid element in assignment pattern
 error: Numeric literal cannot contain consecutive separators
    |
  1 | (1__1)
-   |  ^^
+   |    ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -1864,9 +1867,8 @@ error: Unexpected token '#a' as property key
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   # x
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -1894,10 +1896,11 @@ error: Logical expressions and nullish coalescing cannot be mixed
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'if ( Object === null ) {\n'+
+   | ^
+ 4 | '  throw new Test262Error("#13: Object === null");\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -1906,7 +1909,7 @@ error: Unterminated string literal
 error: Unterminated regular expression literal
    |
  1 | foo[/42
-   |     ^
+   |        ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -1990,7 +1993,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_7n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -2089,7 +2092,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   async \u0023m() { return 42; }
-   |        ^^
+   |          ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -2103,6 +2106,16 @@ error: Expected ')' after for-in expression, but found ';'
    |                  ^
  3 |     break;
    |
+
+✓ test/parser/suite/js/fail/0a8d3e27408647c4.js
+error: Unexpected token ':'
+   |
+ 1 | a::import.defer("foo").bar;
+   |   ^
+ 2 | 
+   |
+   = help: Expected an expression
+
 
 ✓ test/parser/suite/js/fail/0a9618181294366a.js
 error: Invalid element in assignment pattern
@@ -2203,13 +2216,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/0b8892ac402295f7.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/0b9bdd3fe0ff0a7d.js
@@ -2403,7 +2416,7 @@ error: Keywords cannot contain escape characters
 error: Invalid Unicode escape sequence
    |
  1 | \u12
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -2456,13 +2469,13 @@ error: 'throw' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/0cb154a3d03a8c17.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0xa_1_, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/0cc504aa5331b950.module.js
@@ -2533,7 +2546,7 @@ error: 'await' is reserved in an async/module context and cannot be used as an i
 error: Invalid character in identifier
    |
  1 | var\u000Dx;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -2644,13 +2657,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/0dac368d92e4c324.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0x_a_1]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/0db60f9ba9b9f2d1.js
@@ -2692,7 +2705,7 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u002C2;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -2763,7 +2776,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid regular expression flag
    |
  1 | /[a-z]/z
-   | ^
+   |        ^
  2 | 
    |
    = help: Valid regex flags are: `g` (global), `i` (ignoreCase), `m` (multiline), `s` (dotAll), `u` (unicode), `y` (sticky), `d` (hasIndices), `v` (setNotation)
@@ -2906,7 +2919,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u002A2;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -2945,7 +2958,7 @@ error: Unexpected token '>'
 error: Invalid hexadecimal escape sequence
    |
  1 | '\x1   
-   | ^^
+   |   ^
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
 
@@ -3081,8 +3094,9 @@ error: 'function' is reserved and cannot be used as an identifier
 error: Unterminated string literal
    |
  1 | "Hello
-   | ^^^^^^
+   |       ^
  2 | World"
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -3111,7 +3125,7 @@ error: Unexpected token '>'
 error: Unterminated multi-line comment
    |
  1 | /* 
-   | ^^^
+   |    ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -3184,13 +3198,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/1091bb1a9d890382.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_.1_1;
-   | ^^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/1097102285a640d5.js
@@ -3204,7 +3218,7 @@ error: Expected ')' after for-loop update, but found ';'
 error: Unterminated string literal
    |
  1 | """
-   |   ^
+   |    ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -3273,7 +3287,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Binary literal must contain at least one binary digit
    |
  1 | 0B9
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -3396,7 +3410,7 @@ error: Unexpected token ')'
 error: Invalid Unicode escape sequence
    |
  1 | "\u"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -3593,13 +3607,13 @@ error: 'false' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/12bc99b476e719f9.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_.1_1, 0
-   | ^^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/12c2604e09eab949.js
@@ -3688,13 +3702,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/13046f0f91213548.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_01_1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/13244b2953aae790.js
@@ -3845,9 +3859,8 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   # x;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -4030,7 +4043,7 @@ error: Rest element must be the last element
 error: Line terminator not allowed in regular expression literal
    |
  1 | /a\\ /
-   | ^
+   |     ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -4039,7 +4052,7 @@ error: Line terminator not allowed in regular expression literal
 error: Invalid Unicode escape sequence
    |
  1 | ("\u{FFFFFFF}")
-   |  ^^
+   |    ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -4298,7 +4311,7 @@ error: Unexpected token '>'
 error: Exponent part is missing a number
    |
  1 | 1.e
-   | ^^^
+   |    ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -4328,7 +4341,7 @@ error: Unexpected token ')'
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b2_1
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
@@ -4418,8 +4431,10 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
 error: Unterminated string literal
    |
  1 | if (decodeURI("http:
-   |               ^^^^^^
+   |                     ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -4463,6 +4478,16 @@ error: Computed property must have a value
    |    ^
    |
    = help: Add ': value' after the computed key.
+
+
+✓ test/parser/suite/js/fail/17165ca85d75291c.js
+error: Unexpected token ':'
+   |
+ 1 | a::import("foo").bar;
+   |   ^
+ 2 | 
+   |
+   = help: Expected an expression
 
 
 ✓ test/parser/suite/js/fail/171d1ff9c50e13a8.js
@@ -4667,7 +4692,7 @@ error: Unexpected token ')'
 error: The 'u' and 'v' regular expression flags cannot be used together
    |
  1 | /./uv;
-   | ^
+   |      ^
    |
    = help: The 'u' (unicode) and 'v' (unicodeSets) flags are mutually exclusive; use one or the other
 
@@ -4716,7 +4741,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   async # m() {}
-   |        ^^
+   |          ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -4738,8 +4763,10 @@ error: Unterminated string literal
    |
 32 | Array.prototype.splice.call(source, 0, 2 ** 53 + 4);
 33 | }, '
-   |   ^^
+   |     ^
 34 | assert.sameValue(targetLength, 2 ** 53 - 1,
+   | ^
+35 |   'The value of targetLength is expected to be 2 ** 53 - 1');
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -4773,7 +4800,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   async * \u0023m() { return 42; }
-   |          ^^
+   |            ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -4809,7 +4836,7 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | \u200D = []
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -4855,13 +4882,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/190734757bd8d910.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_a_1
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/195089011f8e03f1.js
@@ -4929,13 +4956,13 @@ error: Expected '{' to start class body, but found '+'
 
 
 ✓ test/parser/suite/js/fail/197ed161edda38c1.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0b01_1_}
-   |  ^^^^^^^
+   |         ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/199f674caea558f3.js
@@ -4948,13 +4975,13 @@ error: Expected ')' to close parameter list, but found '='
    |
 
 ✓ test/parser/suite/js/fail/19b53a0b2f963f9e.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1_1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/19cde65a2addabee.js
@@ -4972,7 +4999,7 @@ error: Rest element must be the last element
 error: Unterminated regular expression literal
    |
  1 | /a\/
-   | ^
+   |     ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -5035,7 +5062,7 @@ error: Shorthand property cannot have a default value in object expression
 error: Invalid Unicode escape sequence
    |
  1 | '\u{1F_639}';
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -5135,7 +5162,7 @@ error: Expected '}' to close template expression, but found ';'
 error: Invalid character at start of identifier
    |
  1 | \uD800x
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -5214,7 +5241,7 @@ error: 'function' is reserved and cannot be used as a binding identifier
 error: Invalid Unicode escape sequence
    |
  1 | a\o
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -5245,7 +5272,7 @@ error: Expected ')' after import(), but found ''''
 error: Invalid Unicode escape sequence
    |
  1 | "\u000G"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -5309,7 +5336,7 @@ error: Expected ']' after computed property key, but found 'iter'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_0n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -5374,7 +5401,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Numeric literal cannot contain consecutive separators
    |
  1 | {1_1__}
-   |  ^^^^
+   |      ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -5487,9 +5514,8 @@ error: Rest element must be the last element
 error: Invalid character in identifier
    |
  1 | x = 1;
-   |       ^
  2 | this\u002Ex;
-   | ^^^^^
+   |      ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -5676,7 +5702,7 @@ error: Unexpected token '>'
 error: Line terminator not allowed in regular expression literal
    |
  1 | /a\\  /
-   | ^
+   |     ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -5877,7 +5903,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 08_0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -5886,7 +5912,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Exponent part is missing a number
    |
  1 | 3e-
-   | ^^^
+   |    ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -6536,7 +6562,7 @@ error: A rest element cannot have an initializer
 error: Invalid character at start of identifier
    |
  1 | \u{0}
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -6586,13 +6612,13 @@ error: Lexical declaration cannot appear in a single-statement context
 
 
 ✓ test/parser/suite/js/fail/22e81a52b5074d91.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1_.1_1)
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/22f098f167a45562.js
@@ -6676,9 +6702,8 @@ error: Member expression is not allowed in binding pattern
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   \u0023m() { return 42; }
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -6717,7 +6742,7 @@ error: Invalid element in assignment pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 08_0n
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -6764,13 +6789,13 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/23ca1e84234a1a37.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1.1_E1)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/23cfdb981427a6fa.js
@@ -6822,7 +6847,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated string literal
    |
  1 | var str = ";
-   |          ^^^
+   |             ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -6895,20 +6920,20 @@ error: Expected ')' after function arguments, but found 'v'
 
 
 ✓ test/parser/suite/js/fail/2484d3efcbecb94e.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_a_1, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/24974a25436d83f9.js
 error: Unterminated string literal
    |
  1 | "\\\"
-   | ^^^^^
+   |      ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -6944,13 +6969,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/24c6a0914f8d66c6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0b_01_1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/24cbacbdbafc5396.js
@@ -6963,13 +6988,13 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/24cc89372ddebe75.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0x_1__1}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/24d9394d1eb7875e.module.js
@@ -7093,7 +7118,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   set # m(_) {}
-   |      ^^
+   |        ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -7250,7 +7275,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | a\u11z 
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -7287,7 +7312,7 @@ error: Unexpected token '>'
 error: Numeric literal cannot contain consecutive separators
    |
  1 | {1__1}
-   |  ^^
+   |    ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -7319,7 +7344,7 @@ error: Unexpected token '...'
 error: Unterminated string literal
    |
  1 | '
-   | ^
+   |  ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -7377,7 +7402,7 @@ error: Getter/setter cannot appear in destructuring pattern
 error: Invalid Unicode escape sequence
    |
  1 | "\u{}"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -7487,13 +7512,13 @@ error: Keywords cannot contain escape characters
 
 
 ✓ test/parser/suite/js/fail/2706a86b6698e146.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0b_0_1_1]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/27120e0c1b2d0e95.js
@@ -7549,20 +7574,22 @@ error: 'const' declarations must be initialized
 error: Unterminated string literal
    |
  1 | "
-   | ^
+   |  ^
  2 | str
+   | ^
+ 3 | ing
    |
    = help: Try adding a closing quote here to complete the string
 
 
 ✓ test/parser/suite/js/fail/2771ed94cd20207b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1.1_e1]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2774b3cce5a09798.js
@@ -7685,7 +7712,7 @@ error: Unexpected token ':'
 error: Invalid Unicode escape sequence
    |
  1 | "\u{FFFF"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -7723,7 +7750,7 @@ error: A rest element cannot have an initializer
 error: Invalid Unicode escape sequence
    |
  1 | \ua
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -7827,7 +7854,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | \u007B\u007D;
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -7845,8 +7872,10 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated string literal
    |
  1 | if ((encodeURIComponent("http:
-   |                         ^^^^^^
+   |                               ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -7900,7 +7929,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | "\u111"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -7939,7 +7968,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | i #= 42
-   |  ^^
+   |    ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -8025,12 +8054,12 @@ error: The left-hand side of '**' cannot be an unparenthesized unary expression
 
 
 ✓ test/parser/suite/js/fail/29b902ac17fb2566.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x0_n;
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/29c12b2bbac25282.js
@@ -8090,7 +8119,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   async * \u0023m() { return 42; }
-   |          ^^
+   |            ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -8132,13 +8161,13 @@ error: Expected declaration after 'export', but found 'B'
    |
 
 ✓ test/parser/suite/js/fail/2a1fb4e6d811b42d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0b_0_1_1}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2a2a47c61d8c8985.js
@@ -8227,7 +8256,7 @@ error: Invalid character at start of identifier
    |
  2 |   method() {
  3 |     this.\u0023field;
-   |          ^
+   |           ^
  4 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -8237,7 +8266,7 @@ error: Invalid character at start of identifier
 error: Invalid character in identifier
    |
  1 | var\u2028x;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -8584,7 +8613,7 @@ error: 'const' declarations must be initialized
 error: Unterminated regular expression literal
    |
  1 | /\/
-   | ^
+   |    ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -8599,13 +8628,13 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
    |
 
 ✓ test/parser/suite/js/fail/2c3ba496963b8889.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x__1_1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2c3cbce523ad436e.js
@@ -8650,7 +8679,7 @@ error: Rest element must be the last element
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_0123456789
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -8659,7 +8688,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1_1__;
-   | ^^^^
+   |     ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -8802,13 +8831,14 @@ error: Expected ')' to close parameter list, but found '='
    |
 
 ✓ test/parser/suite/js/fail/2d1756a2a6ae11ac.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_
-   | ^^^^
+   |     ^
  2 | 
+   | ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2d1de23d88922524.js
@@ -8908,8 +8938,9 @@ error: Unterminated string literal
    |
 11 | assert.sameValue(string, "", 'The value of `string` is ""');
 12 | var string = "
-   |             ^^
+   |               ^
 13 | assert.sameValue(string, "
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -8978,7 +9009,7 @@ error: Expected '{' to start class body, but found '=>'
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1__0123456789
-   | ^^
+   |   ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -8995,12 +9026,12 @@ error: 'import' is reserved and cannot be used as an identifier
 ✓ test/parser/suite/js/fail/2daf9186793aa37c.js
 error: Unterminated string literal
    |
-28 | PI_CE, EndTagCE, AttValSE, ElemTagCE, MarkupSPE, XML_SPE];
 29 | var __html=""+
-   |               ^
 30 | '<html xmlns="http:
-   | ^^^^^^^^^^^^^^^^^^^
+   |                    ^
 31 | '      xmlns:xlink="http:
+   | ^
+32 | '  <head><title>Three Namespaces</title></head>\n' +
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -9026,7 +9057,7 @@ error: Getter/setter cannot appear in destructuring pattern
 error: Invalid character in identifier
    |
  1 | var\u0020x;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -9111,7 +9142,7 @@ error: Bad escape sequence in untagged template literal
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0x
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -9160,7 +9191,7 @@ error: A rest element cannot have an initializer
 error: Invalid character at start of identifier
    |
  1 | \u0000
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -9169,7 +9200,7 @@ error: Invalid character at start of identifier
 error: Unterminated template literal
    |
  1 | `${a}a${b}
-   |          ^
+   |           ^
    |
    = help: Try adding a closing backtick (`) here to complete the template
 
@@ -9242,13 +9273,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/2f187e11a35b9b31.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1E_1, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2f23003a9c3a2849.js
@@ -9266,18 +9297,18 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b2n;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
 
 ✓ test/parser/suite/js/fail/2f40d23e46022962.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10_
-   | ^^^
+   |    ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2f4d2b0c0c1f960f.js
@@ -9344,13 +9375,13 @@ error: Unexpected token '%'
 
 
 ✓ test/parser/suite/js/fail/2fc4e34cebc03a49.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0x__1_1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/2fce11080859456b.js
@@ -9433,13 +9464,13 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/3036baab2f81c6e2.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0x_1_1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/304682828de5aed9.js
@@ -9593,7 +9624,7 @@ error: Invalid assignment target
 error: Invalid Unicode escape sequence
    |
  1 | \o
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -9912,7 +9943,7 @@ error: 'void' is reserved and cannot be used as a binding identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 07n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -9967,7 +9998,7 @@ error: The only valid meta property for 'new' is 'new.target'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 09_0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -9991,7 +10022,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 01_0n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -10274,7 +10305,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static async * # m() {}
-   |                 ^^
+   |                   ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -10288,13 +10319,13 @@ error: 'default' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/348cdd033f65efb2.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1.1e_1}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/34929e0bb360a28b.js
@@ -10369,12 +10400,12 @@ error: Expected ';' after class field, but found 'y'
 
 
 ✓ test/parser/suite/js/fail/3508e1a17258072b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b0_
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/3509eb64784738c2.js
@@ -10466,7 +10497,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static set # m(_) {}
-   |             ^^
+   |               ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -10506,7 +10537,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 3x
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -10593,8 +10624,10 @@ error: Unterminated string literal
    |
  3 | }
  4 | if (encodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  5 |   throw new Test262Error('#2: http:
+   | ^
+ 6 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -10751,7 +10784,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   get # m() {}
-   |      ^^
+   |        ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -10792,7 +10825,7 @@ error: A string literal cannot be used as an exported binding without 'from'
 error: Unterminated regular expression literal
    |
  1 | function __func(){/ ABC}
-   |                   ^
+   |                         ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -10812,7 +10845,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   * # m() {}
-   |    ^^
+   |      ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -10859,7 +10892,7 @@ error: Bad escape sequence in untagged template literal
 error: Invalid character in identifier
    |
  1 | a\u0000
-   | ^^
+   |   ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -10879,7 +10912,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static # x = 1;
-   |         ^^
+   |           ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -10962,7 +10995,7 @@ error: Unexpected token '>'
 error: Unterminated string literal
    |
  1 | "\
-   | ^^
+   |   ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -11074,7 +11107,7 @@ error: 'do' is reserved and cannot be used as an identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0\u00620;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -11184,7 +11217,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid hexadecimal escape sequence
    |
  1 | "\x1_0";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
@@ -11302,8 +11335,10 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Unterminated string literal
    |
  1 | if (decodeURI("http:
-   |               ^^^^^^
+   |                     ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -11372,8 +11407,10 @@ error: Invalid element in assignment pattern
 error: Unterminated string literal
    |
  1 | if (decodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -11408,7 +11445,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   async \u0023m() { return 42; }
-   |        ^^
+   |          ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -11487,8 +11524,10 @@ error: Unterminated string literal
    |
  6 | }
  7 | if (decodeURI("http:
-   |               ^^^^^^
+   |                     ^
  8 |   throw new Test262Error('#3: http:
+   | ^
+ 9 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -11512,7 +11551,7 @@ error: 'await' is reserved in an async/module context and cannot be used as an i
 error: Numeric literal cannot contain consecutive separators
    |
  1 | [1__1]
-   |  ^^
+   |    ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -11553,7 +11592,7 @@ error: A rest element cannot have an initializer
 error: Invalid hexadecimal escape sequence
    |
  1 | "\xx";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
@@ -11563,7 +11602,7 @@ error: Invalid hexadecimal escape sequence
 error: Invalid Unicode escape sequence
    |
  1 | \\u0061a 
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -11683,7 +11722,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 3in[]
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -11796,7 +11835,7 @@ error: Shorthand property cannot have a default value in object expression
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0x0__0n;
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -11814,7 +11853,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Invalid character in identifier
    |
  1 | var\u00A0x;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -11872,7 +11911,7 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Invalid regular expression flag
    |
  1 | /./G;
-   | ^
+   |    ^
    |
    = help: Valid regex flags are: `g` (global), `i` (ignoreCase), `m` (multiline), `s` (dotAll), `u` (unicode), `y` (sticky), `d` (hasIndices), `v` (setNotation)
 
@@ -12094,7 +12133,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   * # m() {}
-   |    ^^
+   |      ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -12112,13 +12151,13 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/3f301ee387096e29.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_01_1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/3f4503d90a27d634.js
@@ -12131,13 +12170,13 @@ error: Invalid character at start of identifier
 
 
 ✓ test/parser/suite/js/fail/3f49f2624386d860.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/3f4d40778bba4918.js
@@ -12304,13 +12343,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/402b705e13ce643f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/403c8143130f6315.js
@@ -12360,13 +12399,13 @@ error: 'for await' is only valid in async functions or modules
    |
 
 ✓ test/parser/suite/js/fail/4051255761802690.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1._1_1
-   | ^^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/4057830522dfbc8d.js
@@ -12461,7 +12500,7 @@ error: Expected 'class' keyword, but found 'export'
 error: Invalid Unicode escape sequence
    |
  1 | a\x
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -12507,9 +12546,8 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   #\u200C_ZWNJ;
-   | ^^^^
+   |     ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -12542,23 +12580,25 @@ error: Classes may not have a static property named 'prototype'
 
 
 ✓ test/parser/suite/js/fail/4197001c0e72bafa.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0xa_1_
-   | ^^^^^^
+   |       ^
  2 | 
+   | ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/419fa2ef213db613.js
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'for (var x in this) {\n'+
+   | ^
+ 4 | '  if ( x === \'Math\' ) {\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -12686,7 +12726,7 @@ error: Rest element must be the last element
 error: Invalid Unicode escape sequence
    |
  1 | a\\u0061
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -12709,6 +12749,16 @@ error: 'await using' declarations must be initialized
  3 | }
    |
    = help: Disposable resources require an initial value that implements the dispose protocol.
+
+
+✓ test/parser/suite/js/fail/42c238a81d9398db.js
+error: Unexpected token ':'
+   |
+ 1 | ::import("foo")
+   | ^
+ 2 | 
+   |
+   = help: Expected an expression
 
 
 ✓ test/parser/suite/js/fail/42c2959f547b125c.js
@@ -12797,9 +12847,8 @@ error: Keywords cannot contain escape characters
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   #\u200D_ZWJ;
-   | ^^^^
+   |     ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -12950,13 +12999,13 @@ error: 'enum' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/445bcb9863292c6c.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0o_1_1]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/4468a45b85d0e22a.js
@@ -13136,7 +13185,7 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | var \u2E2F;
-   |    ^^
+   |      ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -13329,7 +13378,7 @@ error: Invalid character at start of identifier
    |
  2 |   method() {
  3 |     this.\u0023field;
-   |          ^
+   |           ^
  4 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -13339,7 +13388,7 @@ error: Invalid character at start of identifier
 error: Invalid Unicode escape sequence
    |
  1 | x\
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -13387,7 +13436,7 @@ error: Unexpected token '>'
 error: Duplicate regular expression flag
    |
  1 | /./gii;
-   | ^
+   |      ^
  2 | 
    |
    = help: Remove the duplicate flag; each flag can only appear once
@@ -13468,13 +13517,13 @@ error: Lexical declaration cannot appear in a single-statement context
 
 
 ✓ test/parser/suite/js/fail/471f7b9936b02f46.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0b01_1_)
-   |  ^^^^^^^
+   |         ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/47275edb5ae5da7d.js
@@ -13644,13 +13693,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/4817e53674c7d401.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1E_1
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/482155035ccd6d6a.js
@@ -13875,8 +13924,9 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | 1 + #
-   |    ^^
+   |      ^
  2 | 
+   | ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -13990,7 +14040,7 @@ error: Unexpected token '>'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 089n
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -14050,7 +14100,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | i #= 0
-   |  ^^
+   |    ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -14059,7 +14109,7 @@ error: Invalid character at start of identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 08n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -14140,7 +14190,7 @@ error: Unexpected token '>'
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b9
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -14177,7 +14227,7 @@ error: Constructor cannot be async
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 3x0
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -14232,7 +14282,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: BigInt literal cannot contain decimal point or exponent
    |
  1 | 2017.8n;
-   | ^^^^^^
+   |       ^
    |
    = help: Try removing the 'n' suffix here, or remove the decimal point/exponent from the number
 
@@ -14398,7 +14448,7 @@ error: A rest element cannot have an initializer
 error: Octal literal must contain at least one octal digit
    |
  1 | 0o
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -14407,9 +14457,8 @@ error: Octal literal must contain at least one octal digit
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   \u0023m() { return 42; }
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -14555,9 +14604,8 @@ error: Unexpected token ')'
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   # m() {}
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -14587,7 +14635,7 @@ error: Rest element is not allowed in parenthesized expression
 error: Invalid Unicode escape sequence
    |
  1 | "\uAA"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -14697,13 +14745,13 @@ error: Expected 'from' after import clause, but found '{'
 
 
 ✓ test/parser/suite/js/fail/4d75f72db9b35249.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_11;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/4d83ab72615f61d6.js
@@ -15175,7 +15223,7 @@ error: Expected ')' after function arguments, but found 'null'
 error: Unterminated string literal
    |
  1 | var str = ';
-   |          ^^^
+   |             ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -15215,7 +15263,7 @@ error: Invalid character at start of identifier
    |
  2 |   method() {
  3 |     foo().\u0023field;
-   |           ^
+   |            ^
  4 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -15352,7 +15400,7 @@ error: Expected ';' after class field, but found 'a'
 error: BigInt literal cannot contain decimal point or exponent
    |
  1 | 1.0n
-   | ^^^
+   |    ^
  2 | 
    |
    = help: Try removing the 'n' suffix here, or remove the decimal point/exponent from the number
@@ -15373,7 +15421,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   async # m() {}
-   |        ^^
+   |          ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -15426,13 +15474,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/518598f1866d3686.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0x__1_1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/518ee39b68d3e30e.js
@@ -15547,7 +15595,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid Unicode escape sequence
    |
  1 | "\uAAA"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -15605,8 +15653,10 @@ error: Unterminated string literal
    |
  3 | }
  4 | if (encodeURI("http:
-   |               ^^^^^^
+   |                     ^
  5 |   throw new Test262Error('#2: http:
+   | ^
+ 6 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -15727,13 +15777,13 @@ error: Keywords cannot contain escape characters
 
 
 ✓ test/parser/suite/js/fail/53618b85bfa4481f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1._1_1;
-   | ^^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/537c4a516d7c8d7f.js
@@ -15836,19 +15886,19 @@ error: Unexpected token ':'
 error: Invalid Unicode escape sequence
    |
  1 | ('\u{2028')
-   |  ^^
+   |    ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
 
 ✓ test/parser/suite/js/fail/5436850e9a8886f7.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1._1_1, 0
-   | ^^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5437b9e3d6bebb1d.js
@@ -15873,7 +15923,7 @@ error: Logical expressions and nullish coalescing cannot be mixed
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0B1a
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -16010,7 +16060,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   * \u0023m() { return 42; }
-   |    ^^
+   |      ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -16031,10 +16081,11 @@ error: Keywords cannot contain escape characters
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'if ( Math === null ) {\n'+
+   | ^
+ 4 | '  throw new Test262Error("#27: Math === null");\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -16123,7 +16174,7 @@ error: Rest element must be the last element
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -16141,7 +16192,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | "\u";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -16171,8 +16222,10 @@ error: Unterminated string literal
    |
  1 | assert.sameValue(RegExp.escape('/'), '\\/', 'solidus character is escaped correctly');
  2 | assert.sameValue(RegExp.escape('
-   |                                ^
+   |                                 ^
  3 | assert.sameValue(RegExp.escape('
+   | ^
+ 4 | assert.sameValue(RegExp.escape('
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -16259,7 +16312,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid Unicode escape sequence
    |
  1 | "\u{1F_639}"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -16327,12 +16380,12 @@ error: Expected ';' after for-loop init, but found 'basic'
    |
 
 ✓ test/parser/suite/js/fail/568e5f904880decd.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/569bc7187c297107.js
@@ -16371,7 +16424,7 @@ error: Parentheses are not allowed in this binding pattern
 error: Invalid Unicode escape sequence
    |
  1 | a\
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -16428,23 +16481,23 @@ error: Classes may not have a static property named 'prototype'
 
 
 ✓ test/parser/suite/js/fail/5711e137cffbdd0a.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b01_1_, 0
-   | ^^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5712a22e2d9915ef.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0o_01_1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/57480a69d61ba6e9.js
@@ -16472,7 +16525,7 @@ error: Rest element must be the last element
 error: Invalid Unicode escape sequence
    |
  1 | ('\u')
-   |  ^^
+   |    ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -16582,13 +16635,13 @@ error: 'enum' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/57d93e9c43f2ebb8.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0b01_1_]
-   |  ^^^^^^^
+   |         ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/57e0917f516019e8.js
@@ -16625,13 +16678,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/5809eef7b00d4ace.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1__1, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/580bd92961da3f9f.js
@@ -16776,7 +16829,7 @@ error: Destructuring declaration in for loop initializer must be initialized
 error: Exponent part is missing a number
    |
  1 | 1.e+z
-   | ^^^^
+   |     ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -16883,7 +16936,7 @@ error: Invalid character at start of identifier
    |
  3 |   m() {
  4 |     this.# x;
-   |          ^
+   |           ^
  5 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -17032,7 +17085,7 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Invalid Unicode escape sequence
    |
  1 | "\u00";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -17100,7 +17153,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid Unicode escape sequence
    |
  1 | "\uA"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -17221,7 +17274,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   async * # m() {}
-   |          ^^
+   |            ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -17329,7 +17382,7 @@ error: Invalid element in assignment pattern
 error: Invalid character at start of identifier
    |
  1 | #[#{}]
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -17446,13 +17499,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/5caf8eda9e02d76c.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_01_1_
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5cb088202e2b3a46.js
@@ -17460,7 +17513,7 @@ error: Unterminated string literal
    |
 11 | }
 12 | assertToStringOrNativeFunction(f, "function\r\n
-   |                                  ^^^^^^^^^^^^^^
+   |                                                ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -17479,7 +17532,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static set # m(_) {}
-   |             ^^
+   |               ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -17493,13 +17546,13 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
    |
 
 ✓ test/parser/suite/js/fail/5ce1a2fd638f8b64.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0x_1_1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5cf595889125e209.js
@@ -17532,8 +17585,10 @@ error: Unexpected token '%'
 error: Unterminated string literal
    |
  1 | if ((encodeURI("http:
-   |                ^^^^^^
+   |                      ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -17586,23 +17641,23 @@ error: 'await using' declarations must be initialized
 
 
 ✓ test/parser/suite/js/fail/5d516db1575af25b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0x_1_1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5d6e47e3d2c4b34f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0b_0_1_1)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5d7101490c95d7a8.js
@@ -17657,7 +17712,7 @@ error: A rest element cannot have an initializer
 error: Invalid Unicode escape sequence
    |
  1 | \u{00__61};
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -17736,7 +17791,7 @@ error: Expected '(' to start parameter list, but found '.'
 error: Unterminated string literal
    |
  1 | "\"
-   | ^^^
+   |    ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -17752,7 +17807,7 @@ error: Bad escape sequence in untagged template literal
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00_0n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -17790,7 +17845,7 @@ error: Unexpected token '>'
 error: BigInt literal cannot contain decimal point or exponent
    |
  1 | 2e9n
-   | ^^^
+   |    ^
  2 | 
    |
    = help: Try removing the 'n' suffix here, or remove the decimal point/exponent from the number
@@ -17837,7 +17892,7 @@ error: Unexpected token '...'
 error: Exponent part is missing a number
    |
  1 | 3e
-   | ^^
+   |   ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -17876,7 +17931,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static # x;
-   |         ^^
+   |           ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -17927,7 +17982,7 @@ error: Unexpected token '...'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00_0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -18013,12 +18068,12 @@ error: Rest parameter must be last formal parameter
 
 
 ✓ test/parser/suite/js/fail/5f5621cca1450878.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5f58c4ffb8378874.js
@@ -18112,13 +18167,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/5fd39839aba542c6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/5fdf4ac92a064996.js
@@ -18345,8 +18400,9 @@ error: Unexpected token '>'
 error: Line terminator not allowed in regular expression literal
    |
  1 | /\
-   | ^
+   |   ^
  2 | 0
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -18384,32 +18440,33 @@ error: 'for (async of ...)' is not allowed, it is ambiguous with 'for await'
 
 
 ✓ test/parser/suite/js/fail/6101b4a475d1f0c4.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x__1_1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/610fe4450d41c81e.js
 error: Invalid Unicode escape sequence
    |
  1 | \u
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
 
 ✓ test/parser/suite/js/fail/61165bb928f134c6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x1_1_
-   | ^^^^^^
+   |       ^
  2 | 
+   | ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/612322ffca48cd66.js
@@ -18476,7 +18533,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Duplicate regular expression flag
    |
  1 | /./gig;
-   | ^
+   |      ^
    |
    = help: Remove the duplicate flag; each flag can only appear once
 
@@ -18511,7 +18568,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Invalid Unicode escape sequence
    |
  1 | \u1
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -18697,7 +18754,7 @@ error: Expected '(' after 'if', but found 'false'
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -18727,7 +18784,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: BigInt literal cannot contain decimal point or exponent
    |
  1 | 0e0n;
-   | ^^^
+   |    ^
    |
    = help: Try removing the 'n' suffix here, or remove the decimal point/exponent from the number
 
@@ -18993,9 +19050,8 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   # x = 1;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -19077,11 +19133,9 @@ error: Expected '{' to start class body, but found '['
 ✓ test/parser/suite/js/fail/65a7e95d594ad7ad.js
 error: Unterminated multi-line comment
    |
- 1 | /*
-   | ^^
  2 | 
  3 | *
-   | ^
+   |  ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -19193,7 +19247,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | \u{0061_};
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -19235,9 +19289,8 @@ error: Unexpected token '?'
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   \u200D_ZWJ;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -19283,18 +19336,18 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid hexadecimal escape sequence
    |
  1 | '\x1
-   | ^^
+   |   ^
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
 
 
 ✓ test/parser/suite/js/fail/66efd4d60285d887.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_1n;
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/66fb7a2ad123acc6.js
@@ -19562,7 +19615,7 @@ error: Async functions can only be declared at the top level or inside a block
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0a
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -19589,7 +19642,7 @@ error: 'catch' is reserved and cannot be used as an identifier
 error: Invalid character at start of identifier
    |
  1 | \u005c
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -19639,7 +19692,7 @@ error: Unexpected token ';'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_0;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -19669,12 +19722,12 @@ error: 'export' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/68df05131d88f838.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b0_n;
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/68f0106ad505b13f.js
@@ -19690,7 +19743,7 @@ error: Unexpected token 'end of file'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 09_0n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -19860,9 +19913,8 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   # x
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -19909,13 +19961,13 @@ error: 'delete' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/69e7a0c382b53cb9.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_11
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6a0672644fbebd0c.js
@@ -19929,7 +19981,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u002D2;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -20042,19 +20094,19 @@ error: 'await' is reserved in an async/module context and cannot be used as an i
 error: Invalid Unicode escape sequence
    |
  1 | var x = /[a-z]/\ux
-   |                ^
+   |                 ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
 
 ✓ test/parser/suite/js/fail/6ac36e283ac44806.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_, 0
-   | ^^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6ace42463566173f.js
@@ -20134,13 +20186,13 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/6b05a7c499ede551.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6b1cd86b591ac75b.js
@@ -20360,7 +20412,7 @@ error: Rest element must be the last element
 error: Invalid Unicode escape sequence
    |
  1 | a\u1z  
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -20424,13 +20476,13 @@ error: 'import' keyword is not allowed here
 
 
 ✓ test/parser/suite/js/fail/6c9d220224920b24.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1.1e_1)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6c9e03fcd46f409e.js
@@ -20457,7 +20509,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | a\uz   
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -20552,7 +20604,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static get # m() {}
-   |             ^^
+   |               ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -20603,20 +20655,20 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static async # m() {}
-   |               ^^
+   |                 ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
 
 ✓ test/parser/suite/js/fail/6d790c31c1cbb0f6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_0_1_1
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6d917f4127334e51.js
@@ -20643,8 +20695,9 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated string literal
    |
  1 | '
-   | ^
+   |  ^
  2 | '
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -20772,7 +20825,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated string literal
    |
  1 | '\x12  
-   | ^^^^^^^
+   |        ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -20799,7 +20852,7 @@ error: 'for await' is only valid in async functions or modules
 error: Invalid character at start of identifier
    |
  1 | \uD800\
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -20839,7 +20892,7 @@ error: Expected ')' after import(), but found ''''
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_9;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -20848,8 +20901,9 @@ error: Identifier cannot immediately follow a numeric literal
 error: Unterminated string literal
    |
  1 | let f = Function("a", "  b, c
-   |                      ^^^^^^^^
+   |                              ^
  2 | assertToStringOrNativeFunction(f, "function anonymous(a,  b, c
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -20895,13 +20949,13 @@ error: Keywords cannot contain escape characters
 
 
 ✓ test/parser/suite/js/fail/6f455c2fda6fa149.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1._1_1)
-   |  ^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6f48e8f4f587e566.js
@@ -20915,13 +20969,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/6f4b37810a018be0.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/6f541ea029e10c06.js
@@ -20939,7 +20993,7 @@ error: Invalid element in assignment pattern
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0X
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -21003,9 +21057,8 @@ error: Expected ')' after constructor arguments, but found '{'
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   \u0023field;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -21187,7 +21240,7 @@ error: Keywords cannot contain escape characters
 error: Unterminated string literal
    |
  1 | assert.sameValue(eval("0
-   |                       ^^
+   |                         ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -21264,14 +21317,25 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
    = help: Only identifiers or member expressions (without optional chaining) are allowed inside parentheses in assignment patterns.
 
 
+✓ test/parser/suite/js/fail/710506f8817554bd.js
+error: Unexpected token ':'
+   |
+ 1 | ::import("foo").bar;
+   | ^
+ 2 | 
+   |
+   = help: Expected an expression
+
+
 ✓ test/parser/suite/js/fail/71233daadbce0b37.js
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'if ( eval === null ) {\n'+
+   | ^
+ 4 | '  throw new Test262Error("#4: eval === null");\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -21305,13 +21369,13 @@ error: Optional chaining is not allowed in assignment pattern
 
 
 ✓ test/parser/suite/js/fail/715048ca30ec3d7b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0o1_1_}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/715a2e04f291765d.js
@@ -21549,12 +21613,12 @@ error: Keywords cannot contain escape characters
 
 
 ✓ test/parser/suite/js/fail/726e68487f09b9fc.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o0_n;
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/72796a0333b7d720.js
@@ -21572,7 +21636,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1.a
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -21673,7 +21737,7 @@ error: 'super' must be followed by a call or property access
 error: The 'u' and 'v' regular expression flags cannot be used together
    |
  1 | /a/ugv;
-   | ^
+   |       ^
  2 | 
    |
    = help: The 'u' (unicode) and 'v' (unicodeSets) flags are mutually exclusive; use one or the other
@@ -21764,7 +21828,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid Unicode escape sequence
    |
  1 | a\u113
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -21774,7 +21838,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static * # m() {}
-   |           ^^
+   |             ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -21784,7 +21848,7 @@ error: Invalid character at start of identifier
 error: Invalid Unicode escape sequence
    |
  1 | "\ux";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -21794,7 +21858,7 @@ error: Invalid Unicode escape sequence
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0b0__0
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -21821,7 +21885,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | "\u11"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -21906,13 +21970,13 @@ error: 'typeof' is reserved and cannot be used as an imported binding
    |
 
 ✓ test/parser/suite/js/fail/749e2e5a437cb498.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1_
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/74be61e344f92145.js
@@ -22062,7 +22126,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated string literal
    |
  1 | '\\\'
-   | ^^^^^
+   |      ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -22102,7 +22166,7 @@ error: Expected '(' for method definition, but found 'foo'
 error: Unterminated string literal
    |
  1 | var str = """;
-   |             ^^
+   |               ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -22111,7 +22175,7 @@ error: Unterminated string literal
 error: Invalid character in identifier
    |
  1 | x\u005c
-   | ^^
+   |   ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -22138,7 +22202,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | \uD800
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -22284,7 +22348,7 @@ error: 'class' is reserved and cannot be used as a binding identifier
 error: Invalid Unicode escape sequence
    |
  1 | \u{110000}
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -22338,7 +22402,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character in identifier
    |
  1 | var a\u2E2F;
-   |    ^^^
+   |       ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -22417,12 +22481,12 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/77767e17d0d3fa6d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/777d8a948b7471cc.js
@@ -22565,7 +22629,7 @@ error: Expected '}' to close function body, but found 'end of file'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 09n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -22631,7 +22695,7 @@ error: Unexpected token '@' in binding pattern
 error: Invalid Unicode escape sequence
    |
  1 | "\u000";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -22838,13 +22902,13 @@ error: Destructuring declaration in for loop initializer must be initialized
 
 
 ✓ test/parser/suite/js/fail/79720619060a9a56.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0o_1_1)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/7974c69bdfcceea8.js
@@ -23144,8 +23208,9 @@ error: Line terminator not allowed in regular expression literal
    |
  2 | assert.sameValue(/[/]/.test("x"), false, "Forward slash");
  3 | assert(/[
-   |        ^
+   |          ^
  4 | assert.sameValue(/[
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -23630,10 +23695,11 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'for (var x in this) {\n'+
+   | ^
+ 4 | '  if ( x === \'Object\' ) {\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -23696,8 +23762,10 @@ error: Rest element must be the last element
 error: Unterminated string literal
    |
  1 | if (encodeURI("http:
-   |               ^^^^^^
+   |                     ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -23724,8 +23792,9 @@ error: Async functions can only be declared at the top level or inside a block
 error: Line terminator not allowed in regular expression literal
    |
  1 | var x = /[a-z
-   |         ^
+   |              ^
  2 | ]/\ux
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -23925,7 +23994,7 @@ error: 'const' is reserved and cannot be used as a binding identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00b0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -23975,13 +24044,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/7edc0b65a09b28a2.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_01_1_
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/7ef7cc49af07f6f2.module.js
@@ -24004,13 +24073,13 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/7f12eed63081e486.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0x1_1_}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/7f1cf8de7b878885.js
@@ -24033,7 +24102,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid Unicode escape sequence
    |
  1 | \u{_0061};
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -24148,7 +24217,7 @@ error: Try statement requires catch or finally clause
 error: Line terminator not allowed in regular expression literal
    |
  1 | //
-   | ^
+   |  ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -24194,13 +24263,13 @@ error: Parentheses are not allowed in this binding pattern
 
 
 ✓ test/parser/suite/js/fail/7fe48edd59e8dd88.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1_1_
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/7ff2156c9c69c424.js
@@ -24223,9 +24292,8 @@ error: 'else' is reserved and cannot be used as an identifier
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   \u0023field;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -24455,7 +24523,7 @@ error: Expected 'from' after import clause, but found ','
 error: Invalid Unicode escape sequence
    |
  1 | "\u12_34"
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -24570,7 +24638,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | var \u200D;
-   |    ^^
+   |      ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -24598,7 +24666,7 @@ error: Unexpected token '.'
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0xgn;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -24607,7 +24675,7 @@ error: Hexadecimal literal must contain at least one hex digit
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0x0__0
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -24641,7 +24709,7 @@ error: Rest element is not allowed in parenthesized expression
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_8;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -24659,7 +24727,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid Unicode escape sequence
    |
  1 | \\u0061a
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -24724,7 +24792,7 @@ error: Keywords cannot contain escape characters
 error: Unterminated regular expression literal
    |
  1 | /a
-   | ^
+   |   ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -24786,13 +24854,13 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/834a0077ec5badaa.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o01_8
-   | ^^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/834b03ee2422cd06.js
@@ -25129,7 +25197,7 @@ error: Invalid element in assignment pattern
 error: Unterminated multi-line comment
    |
  1 | /*CHECK#1/
-   | ^^^^^^^^^^
+   |           ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -25138,7 +25206,7 @@ error: Unterminated multi-line comment
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 09.x
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -25193,7 +25261,7 @@ error: Destructuring declaration must have an initializer
 error: Invalid Unicode escape sequence
    |
  1 | \\u0061
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -25243,7 +25311,7 @@ error: Unexpected token '*'
 error: Invalid character in identifier
    |
  1 | var\u000Bx;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -25283,7 +25351,7 @@ error: 'const' declarations must be initialized
 error: Invalid Unicode escape sequence
    |
  1 | \u00__61;
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -25392,7 +25460,7 @@ error: 'if' is reserved and cannot be used as a binding identifier
 error: Unterminated multi-line comment
    |
  1 | /*hello
-   | ^^^^^^^
+   |        ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -25495,13 +25563,14 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/8711ed70d3b4fb64.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o1_1_
-   | ^^^^^^
+   |       ^
  2 | 
+   | ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8712ed1a91c3cf97.js
@@ -25904,8 +25973,9 @@ error: Keywords cannot contain escape characters
 error: Unterminated string literal
    |
  1 | ('
-   |  ^
+   |   ^
  2 | ')
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -26032,13 +26102,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/8a0c7fe1f19e023e.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8a107814790d53d7.js
@@ -26075,7 +26145,7 @@ error: Unexpected token ']'
 error: Unterminated string literal
    |
  1 | "
-   | ^
+   |  ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -26084,7 +26154,7 @@ error: Unterminated string literal
 error: Binary literal must contain at least one binary digit
    |
  1 | 0B
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -26093,7 +26163,7 @@ error: Binary literal must contain at least one binary digit
 error: Unterminated regular expression literal
    |
  1 | /
-   | ^
+   |  ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -26203,13 +26273,13 @@ error: Expected ';' after class field, but found '=='
 
 
 ✓ test/parser/suite/js/fail/8b026d11777d7f1a.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0x_1__1)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8b0829c05c98e735.js
@@ -26247,9 +26317,8 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   # x = 1;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -26268,7 +26337,7 @@ error: Unexpected token '(' in binding pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 01a
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -26470,9 +26539,8 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   #\u0000;
-   | ^^^^
+   |     ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -26528,13 +26596,13 @@ error: Unexpected token ';'
 
 
 ✓ test/parser/suite/js/fail/8c27d85432775715.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0xa_1_)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8c353ce78b905b58.js
@@ -26587,20 +26655,20 @@ error: Invalid element in assignment pattern
 
 
 ✓ test/parser/suite/js/fail/8c6248d413e2a634.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0o_1_1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8c6face33e963aba.js
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_1;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -26709,10 +26777,11 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'for (var x in this) {\n'+
+   | ^
+ 4 | '  if ( x === \'eval\' ) {\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -26730,7 +26799,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated template literal
    |
  1 | `
-   | ^
+   |  ^
    |
    = help: Try adding a closing backtick (`) here to complete the template
 
@@ -26739,7 +26808,7 @@ error: Unterminated template literal
 error: Unterminated multi-line comment
    |
  1 | /**
-   | ^^^
+   |    ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -26762,13 +26831,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/8d89656e98f0eb9b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_0_1_1, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8d9f6f2c6df045c4.js
@@ -26784,7 +26853,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid character at start of identifier
    |
  1 | \u005B\u005D;
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -26829,12 +26898,12 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/8de7fbb96d97c9d3.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10._1
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8df1ea11d67bb17e.js
@@ -26878,8 +26947,9 @@ error: Expected ';' after class field, but found '{'
 error: Line terminator not allowed in regular expression literal
    |
  1 | /test
-   | ^
+   |      ^
  2 | /
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -27134,10 +27204,11 @@ error: Rest element must be the last element
 error: Unterminated string literal
    |
  1 | var evalStr =
-   |              ^
  2 | '
-   | ^
+   |  ^
  3 | 'if ( NaN === null ) {\n'+
+   | ^
+ 4 | '  throw new Test262Error("#1: NaN === null");\n'+
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -27155,7 +27226,7 @@ error: Invalid element in assignment pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0__0123456789
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -27189,13 +27260,13 @@ error: Unexpected token '%'
 
 
 ✓ test/parser/suite/js/fail/8f37b10991c469bf.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0b_01_1_}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/8f39e7fd49bee152.js
@@ -27359,7 +27430,7 @@ error: A rest element cannot have an initializer
 error: Octal literal must contain at least one octal digit
    |
  1 | 0o9
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -27426,7 +27497,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 07_0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -27565,22 +27636,22 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/918d618f820e3d3f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_n;
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/918ded642401581c.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_0_1_1;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/91960d765c0bfa51.js
@@ -27721,7 +27792,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid Unicode escape sequence
    |
  1 | a\u
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -27730,7 +27801,7 @@ error: Invalid Unicode escape sequence
 error: Invalid hexadecimal escape sequence
    |
  1 | '\x
-   | ^^
+   |   ^
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
 
@@ -27788,7 +27859,7 @@ error: Rest element must be the last element
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b2;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -27830,13 +27901,13 @@ error: 'extends' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/93b15d9d6c4f74f7.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0x_a_1)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/93b6219d903e9752.js
@@ -27988,7 +28059,7 @@ error: Generators can only be declared at the top level or inside a block
 error: Invalid Unicode escape sequence
    |
  1 | var x = /[a-z]/\\ux
-   |                ^
+   |                 ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -28153,7 +28224,7 @@ error: Expected 'while' after do statement body, but found ';'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u005F0123456789n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -28248,13 +28319,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/95807eb8be193f11.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_E1, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/958e7ba534ba5cb2.js
@@ -28270,7 +28341,7 @@ error: Lexical declaration cannot appear in a single-statement context
 error: Invalid character at start of identifier
    |
  1 | var 🀒
-   |    ^
+   |     ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -28330,7 +28401,7 @@ error: A rest element cannot have an initializer
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0b0__0n;
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -28535,8 +28606,10 @@ error: Unterminated string literal
    |
  3 | }
  4 | if (decodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  5 |   throw new Test262Error('#2: http:
+   | ^
+ 6 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -28545,9 +28618,8 @@ error: Unterminated string literal
 error: Invalid character at start of identifier
    |
  1 | class Foo {
-   |            ^
  2 |   #"p" = x
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -28635,7 +28707,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Invalid character at start of identifier
    |
  1 | var ⸯ;
-   |    ^
+   |     ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -28672,7 +28744,7 @@ error: Rest element cannot have a trailing comma in array destructuring.
 error: Unterminated regular expression literal
    |
  1 | [/[/]
-   |  ^
+   |      ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -28762,7 +28834,7 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0008n;
-   | ^^^^
+   |     ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -28807,7 +28879,7 @@ error: 'import' keyword is not allowed here
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1__1
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -28838,8 +28910,10 @@ error: Unterminated string literal
    |
 37 |   ["islamic-umalqura", 1445, 1, "M01", 1, "ah", 1445, "recent year"],
 38 |   ["islamic-umalqura", -6823, 1, "M01", 1, "bh", 6824, "https:
-   |                                                       ^^^^^^^^
+   |                                                               ^
 39 |   ["persian", 1395, 1, "M01", 1, "ap", 1395, "leap year 1395"],
+   | ^
+40 |   ["persian", 1396, 1, "M01", 1, "ap", 1396, "common year 1396"],
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -28849,8 +28923,9 @@ error: Unterminated string literal
    |
  1 | let GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
  2 | let g = GeneratorFunction("a", "  b, c
-   |                               ^^^^^^^^
+   |                                       ^
  3 | assertToStringOrNativeFunction(g, "function* anonymous(a,  b, c
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -28909,13 +28984,13 @@ error: 'this' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/99b3626d4b5ac556.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_a_1;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/99b8550126923fc5.js
@@ -29023,22 +29098,21 @@ error: Rest element must be the last element
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   #\u0000;
-   | ^^^^
+   |     ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
 
 ✓ test/parser/suite/js/fail/9a37bb08aedadf3a.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_e1
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9a6a653922e10fa8.js
@@ -29063,13 +29137,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/9a7b05912764a2be.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0xa_1_}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9a8aac1d50132aac.js
@@ -29152,7 +29226,7 @@ error: Unexpected token '>'
 error: Line terminator not allowed in regular expression literal
    |
  1 | / /
-   | ^
+   |  ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -29183,9 +29257,8 @@ error: A rest element cannot have an initializer
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   # m() {}
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -29315,13 +29388,13 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
    |
 
 ✓ test/parser/suite/js/fail/9c1b1cc1b4c22709.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0o_1_1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9c286666a4979cd2.js
@@ -29364,13 +29437,13 @@ error: 'import' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/9c7fb652d4bbaa72.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0xa_1_;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9c9196e04a0615c0.js
@@ -29405,7 +29478,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0o1a
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -29431,13 +29504,13 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/9cb0c61f5e6b9c0d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1.1_E1}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9cbce7d794e8d679.js
@@ -29509,9 +29582,8 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | class Foo {
-   |            ^
  2 |   #2 = y
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -30011,13 +30083,13 @@ error: Bad escape sequence in untagged template literal
    |
 
 ✓ test/parser/suite/js/fail/9f7b07def1d7c435.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1._1_1]
-   |  ^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/9f8bf490359bd4aa.js
@@ -30060,8 +30132,10 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated string literal
    |
  1 | if ((encodeURIComponent("http:
-   |                         ^^^^^^
+   |                               ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -30179,7 +30253,7 @@ error: Async functions can only be declared at the top level or inside a block
 error: Invalid Unicode escape sequence
    |
  1 | var \u{00_76} = 1;
-   |    ^^
+   |      ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -30207,7 +30281,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static * # m() {}
-   |           ^^
+   |             ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -30275,7 +30349,7 @@ error: Unexpected token '>'
 error: Invalid character at start of identifier
    |
  1 | function __func(){# ABC}
-   |                   ^
+   |                    ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -30285,7 +30359,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static # m() {}
-   |         ^^
+   |           ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -30401,13 +30475,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/a1bc8b8f1a20e8dc.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a1d3004a5fc97560.js
@@ -30522,7 +30596,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Invalid character at start of identifier
    |
  1 | function fn() {#!
-   |                ^
+   |                 ^
  2 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -30551,12 +30625,12 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/a2a47ce3d5eafb67.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10._e1
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a2b993d6a7b964e2.js
@@ -30731,7 +30805,7 @@ error: Invalid character at start of identifier
    |
  3 |   m() {
  4 |     this.# x;
-   |          ^
+   |           ^
  5 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -30766,13 +30840,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/a3be6d0b316ba903.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1.1E_1]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a3d3adfd4a636361.js
@@ -30936,13 +31010,13 @@ error: Expected '(' for getter/setter definition, but found ';'
 
 
 ✓ test/parser/suite/js/fail/a4a983d8d6e7e825.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a4c64a5f8beac7cc.js
@@ -30960,7 +31034,7 @@ error: Unexpected token '=>' in expression
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 10__0123456789
-   | ^^^
+   |    ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -30978,7 +31052,7 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
 error: Invalid Unicode escape sequence
    |
  1 | var x = /[a-z\n]/\ux
-   |                  ^
+   |                   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -31028,7 +31102,7 @@ error: Optional chaining is not allowed in assignment pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0x3in[]
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -31048,7 +31122,7 @@ error: Rest element must be the last element
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 0o0__0n;
-   | ^^^^
+   |     ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -31150,13 +31224,13 @@ error: 'extends' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/a5d50fafe84685df.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o1_1_, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a5d8b89b947e04ab.js
@@ -31353,13 +31427,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/a745d320302eb2b8.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0o_11)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a7571e2f3c5d075c.js
@@ -31406,7 +31480,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0.toString
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -31502,8 +31576,10 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Unterminated string literal
    |
  1 | if ((encodeURI("http:
-   |                ^^^^^^
+   |                      ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -31542,7 +31618,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static get # m() {}
-   |             ^^
+   |               ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -31570,7 +31646,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | \x
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -31769,7 +31845,7 @@ error: Async functions can only be declared at the top level or inside a block
 error: Invalid Unicode escape sequence
    |
  1 | \
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -31824,7 +31900,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   get # m() {}
-   |      ^^
+   |        ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -31869,6 +31945,7 @@ error: Rest element must be the last element
    = help: No elements can follow the rest element in a destructuring pattern.
 
 
+✗ test/parser/suite/js/fail/a95b80985f6ba820.js (expected error, but parsed successfully)
 ✓ test/parser/suite/js/fail/a95caa7436f7ed2e.js
 error: Getter/setter cannot appear in destructuring pattern
    |
@@ -31891,19 +31968,19 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_9n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
 
 ✓ test/parser/suite/js/fail/a97fdb4731ff2ee8.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0x_a_1}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a9818bf25b403323.js
@@ -31914,13 +31991,13 @@ error: 'default' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/a9b8dfd38e71bdcf.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1_1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/a9bc2da8dcd0ea6f.js
@@ -31998,8 +32075,10 @@ error: Unexpected token '>'
 error: Unterminated string literal
    |
  1 | if (decodeURI("http:
-   |               ^^^^^^
+   |                     ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -32039,7 +32118,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | '\u'
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -32048,9 +32127,8 @@ error: Invalid Unicode escape sequence
 error: Invalid character at start of identifier
    |
  1 | class Spaces {
-   |               ^
  2 |   #  wrongSpaces() {
-   | ^^^
+   |    ^
  3 |     return fail();
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32149,8 +32227,9 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Line terminator not allowed in regular expression literal
    |
  1 | /a\
-   | ^
+   |    ^
  2 | /
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -32196,12 +32275,12 @@ error: Setter must have exactly one parameter
 
 
 ✓ test/parser/suite/js/fail/aae6ebac8a9f5c80.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1n;
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/aae75623a18fa153.module.js
@@ -32252,7 +32331,7 @@ error: Shorthand property cannot have a default value in object expression
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 08_0n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -32274,23 +32353,23 @@ error: 'return' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/ab5a4bad29220340.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0o_01_1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ab62b21ef6515041.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x1_1_;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ab7d92c6977a051a.js
@@ -32298,7 +32377,7 @@ error: Invalid character at start of identifier
    |
  6 | m() {
  7 |     this.f().# x;
-   |              ^
+   |               ^
  8 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32328,7 +32407,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u002B2;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -32337,7 +32416,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Invalid character at start of identifier
    |
  1 | var \uD83B\uDE00
-   |    ^^
+   |      ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32367,7 +32446,7 @@ error: Rest element must be the last element
 error: Invalid character at start of identifier
    |
  1 | var \u200C;
-   |    ^^
+   |      ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -32376,7 +32455,7 @@ error: Invalid character at start of identifier
 error: Invalid Unicode escape sequence
    |
  1 | "\u{FFZ}"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -32486,9 +32565,8 @@ error: Unexpected token ';'
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   \u0000;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32598,7 +32676,7 @@ error: Expected an identifier, but found '%'
 error: Invalid Unicode escape sequence
    |
  1 | ("\u{110000}")
-   |  ^^
+   |    ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -32676,7 +32754,7 @@ error: Rest element must be the last element
 error: Invalid character at start of identifier
    |
  1 | # + 1;
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32698,7 +32776,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   * \u0023m() { return 42; }
-   |    ^^
+   |      ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -32736,7 +32814,7 @@ error: Unexpected token '...'
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0xz
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -32866,8 +32944,10 @@ error: Unterminated string literal
    |
 71 |   "Get:4",
 72 | ], 'The value of traps is expected to be [\n
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^
 73 | assert.sameValue(arrayLike.length, 2 ** 53 + 2, 'The value of arrayLike.length is expected to be 2 ** 53 + 2');
+   | ^
+74 | assert.sameValue(arrayLike[0], "2**53-2", 'The value of arrayLike[0] is expected to be "2**53-2"');
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -32911,13 +32991,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/ae30b83493844709.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_e1, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ae3fab281c1b0545.js
@@ -33102,7 +33182,7 @@ error: 'delete' is reserved and cannot be used as a binding identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_1n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -33230,13 +33310,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/b08969e3f2dd99b2.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x__1_1_
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b0ad260b61ba0bd1.js
@@ -33299,7 +33379,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid Unicode escape sequence
    |
  1 | \\
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -33465,13 +33545,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/b20c4a2ad4fdc5c1.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0xa_1_]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b211902b6f5d7d0b.js
@@ -33525,8 +33605,9 @@ error: Unterminated string literal
    |
  2 | if (x !== 0) {
  3 |   throw new Test262Error('#1: var x = 0;
-   |                          ^^^^^^^^^^^^^^^
+   |                                         ^
  4 | }
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -33609,7 +33690,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated regular expression literal
    |
  1 | /test
-   | ^
+   |      ^
    |
    = help: Try adding a closing slash (/) here, optionally followed by flags (g, i, m, etc.)
 
@@ -33747,7 +33828,7 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Invalid hexadecimal escape sequence
    |
  1 | ('\x')
-   |  ^^
+   |    ^
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
 
@@ -33764,20 +33845,20 @@ error: Unexpected token ':'
 
 
 ✓ test/parser/suite/js/fail/b40522fa5e2ad8e8.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0o_1_1_]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b4161f5314d49347.js
 error: Invalid Unicode escape sequence
    |
  1 | \u{FFFF
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -33839,7 +33920,7 @@ error: Empty parentheses are only valid as arrow function parameters
 error: Octal literal must contain at least one octal digit
    |
  1 | 0O9
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -33955,7 +34036,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   set # m(_) {}
-   |      ^^
+   |        ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -33996,12 +34077,12 @@ error: Bad escape sequence in untagged template literal
    |
 
 ✓ test/parser/suite/js/fail/b59bac6bdfe524e1.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_1
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b59f4c90dc652777.js
@@ -34038,7 +34119,7 @@ error: Classes may not have a static property named 'prototype'
 error: Invalid hexadecimal escape sequence
    |
  1 | ('\x0')
-   |  ^^
+   |    ^
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
 
@@ -34156,7 +34237,7 @@ error: Unexpected token '>'
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0xg
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -34171,13 +34252,13 @@ error: Invalid element in assignment pattern
 
 
 ✓ test/parser/suite/js/fail/b6a06904660a84dc.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b01_1_;
-   | ^^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b6a72a718cb7ca67.js
@@ -34233,7 +34314,7 @@ error: Keywords cannot contain escape characters
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0O1a
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -34260,13 +34341,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/b6fa75c2827c3d4b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1E_1;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b7000879725e78f1.js
@@ -34363,13 +34444,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/b793b1e17342c415.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_.1_1
-   | ^^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b799084945fcdb79.js
@@ -34388,7 +34469,7 @@ error: Invalid operand for increment/decrement operator
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1__1, 0
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -34525,7 +34606,7 @@ error: Unexpected token '>'
 error: Invalid Unicode escape sequence
    |
  1 | "\u1"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -34550,7 +34631,7 @@ error: 'true' is reserved and cannot be used as a binding identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0__0123456789n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -34689,13 +34770,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/b8d7541002cd888c.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0x_1__1]
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b8de6b7c0e5753f1.js
@@ -34815,13 +34896,14 @@ error: Rest parameter may not have a trailing comma
 
 
 ✓ test/parser/suite/js/fail/b949446b09adc8b1.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b01_1_
-   | ^^^^^^^
+   |        ^
  2 | 
+   | ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/b94cccf4bc5e6c21.module.js
@@ -34853,7 +34935,7 @@ error: Try statement requires catch or finally clause
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00_0
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -34891,6 +34973,16 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
    |        ^
    |
    = help: Try inserting a semicolon here
+
+
+✓ test/parser/suite/js/fail/b9b7ab48ffbaa0ce.js
+error: Unexpected token ':'
+   |
+ 1 | ::import.defer("foo").bar;
+   | ^
+ 2 | 
+   |
+   = help: Expected an expression
 
 
 ✓ test/parser/suite/js/fail/b9d27f46be458baa.js
@@ -34954,13 +35046,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/ba203f5e99d4a0a5.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0x1_1_)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ba2d36d35efa68ec.js
@@ -34973,13 +35065,13 @@ error: Unexpected token 'end of file'
 
 
 ✓ test/parser/suite/js/fail/ba402ec141596a06.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1_.1_1]
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ba462026454b41cd.js
@@ -35139,13 +35231,13 @@ error: Expected ',' or '}' in object, but found '++'
 
 
 ✓ test/parser/suite/js/fail/bb785acb6af12a14.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0x1_1_]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/bb9d4f75e0c139c6.js
@@ -35171,8 +35263,10 @@ error: 'await' is reserved in an async/module context and cannot be used as a bi
 error: Unterminated string literal
    |
  1 | if (decodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -35200,9 +35294,8 @@ error: Rest element must be the last element
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   #\u200D_ZWJ;
-   | ^^^^
+   |     ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -35418,7 +35511,7 @@ error: Rest element must be the last element
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0xZ_1
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
@@ -35472,13 +35565,13 @@ error: Unexpected token ']'
 
 
 ✓ test/parser/suite/js/fail/bd2678c8905dcf45.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o1_1_;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/bd3dbd870251ed9f.js
@@ -35524,8 +35617,9 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Unterminated string literal
    |
  1 | var x = "
-   |        ^^
+   |          ^
  2 | 
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -35534,7 +35628,7 @@ error: Unterminated string literal
 error: Invalid Unicode escape sequence
    |
  1 | a\u1
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -35661,13 +35755,13 @@ error: Unexpected token '#x' as property key
 
 
 ✓ test/parser/suite/js/fail/becf6869e69f8a88.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_11, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/bed71f16aea08138.js
@@ -35731,7 +35825,7 @@ error: Invalid character at start of identifier
 error: Invalid character in identifier
    |
  1 | x\u002a
-   | ^^
+   |   ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -35750,7 +35844,7 @@ error: Unexpected token '?'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0x1z
-   | ^^^
+   |    ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -35952,7 +36046,7 @@ error: Expected identifier or string literal, but found '%'
 error: Invalid character at start of identifier
    |
  1 | var 𫠞_ = 12;
-   |    ^
+   |     ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -35961,7 +36055,7 @@ error: Invalid character at start of identifier
 error: BigInt literal cannot contain decimal point or exponent
    |
  1 | .0000000001n;
-   | ^^^^^^^^^^^
+   |            ^
    |
    = help: Try removing the 'n' suffix here, or remove the decimal point/exponent from the number
 
@@ -36119,7 +36213,7 @@ error: 'break' is reserved and cannot be used as a binding identifier
 error: Invalid character in identifier
    |
  1 | var\u000Ax;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -36148,7 +36242,7 @@ error: 'super' cannot be used as the target of 'new'
 error: Unterminated string literal
    |
  1 | '\'
-   | ^^^
+   |    ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -36204,8 +36298,10 @@ error: Member expression is not allowed in binding pattern
 error: Unterminated string literal
    |
  1 | eval("
-   |      ^
+   |       ^
  2 | var x = 0;
+   | ^
+ 3 | eval("
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -36233,7 +36329,7 @@ error: Rest element must be the last element
 error: Hexadecimal literal must contain at least one hex digit
    |
  1 | 0xG
-   | ^^
+   |   ^
    |
    = help: Try adding at least one hex digit (0-9, a-f, A-F) here after '0x'
 
@@ -36374,9 +36470,8 @@ error: Unexpected token ')'
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   \u0000;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -36387,7 +36482,7 @@ error: Unterminated string literal
    |
 11 | }
 12 | assertToStringOrNativeFunction(f, "function\r
-   |                                  ^^^^^^^^^^^^
+   |                                              ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -36491,7 +36586,7 @@ error: Getter/setter cannot appear in destructuring pattern
 error: Invalid character at start of identifier
    |
  1 | #=
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -36509,7 +36604,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Unterminated string literal
    |
  1 | '''
-   |   ^
+   |    ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -36518,7 +36613,7 @@ error: Unterminated string literal
 error: Invalid character at start of identifier
    |
  1 | \uD800\u
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -36703,13 +36798,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/c4be7b9650ea07e1.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1_;
-   | ^^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/c4dd271c54f5774c.js
@@ -36723,13 +36818,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/c4df5a0bcbd4d89d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o_1_1, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/c4e8aeda923ae7a0.module.js
@@ -36747,7 +36842,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static async * # m() {}
-   |                 ^^
+   |                   ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -36847,13 +36942,13 @@ error: Expected ';' after for-loop init, but found ')'
    |
 
 ✓ test/parser/suite/js/fail/c5522f9cb824b642.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0o_1_1}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/c552d2e0c26c1921.js
@@ -36870,7 +36965,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static async # m() {}
-   |               ^^
+   |                 ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -36950,12 +37045,12 @@ error: 'yield' is reserved in a generator context and cannot be used as a bindin
    |
 
 ✓ test/parser/suite/js/fail/c5bab557c7571617.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10_n;
-   | ^^^
+   |    ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/c5ca38158adc070c.js
@@ -36991,7 +37086,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid Unicode escape sequence
    |
  1 | \u{}
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -37198,7 +37293,7 @@ error: Unexpected token '>'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 016432n
-   | ^^^^^^
+   |       ^
  2 | 
    |
    = help: Try adding whitespace here between the number and identifier
@@ -37259,8 +37354,10 @@ error: Unterminated string literal
    |
 37 |   ["islamic-umalqura", 1445, 1, "M01", 1, "ah", 1445, "recent year"],
 38 |   ["islamic-umalqura", -6823, 1, "M01", 1, "bh", 6824, "https:
-   |                                                       ^^^^^^^^
+   |                                                               ^
 39 |   ["persian", 1395, 1, "M01", 1, "ap", 1395, "leap year 1395"],
+   | ^
+40 |   ["persian", 1396, 1, "M01", 1, "ap", 1396, "common year 1396"],
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -37280,7 +37377,7 @@ error: Classes may not have a static field named 'constructor'
 error: Invalid hexadecimal escape sequence
    |
  1 | "\x0";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')
@@ -37439,7 +37536,7 @@ error: Unexpected token 'end of file' in binding pattern
 error: Invalid Unicode escape sequence
    |
  1 | "\u
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -37487,8 +37584,9 @@ error: Unterminated string literal
    |
  2 | var AsyncGenerator = f.constructor;
  3 | var g = AsyncGenerator("a", "  b, c
-   |                            ^^^^^^^^
+   |                                    ^
  4 | assertToStringOrNativeFunction(g, "async function* anonymous(a,  b, c
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -37642,7 +37740,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid regular expression flag
    |
  1 | /./a
-   | ^
+   |    ^
    |
    = help: Valid regex flags are: `g` (global), `i` (ignoreCase), `m` (multiline), `s` (dotAll), `u` (unicode), `y` (sticky), `d` (hasIndices), `v` (setNotation)
 
@@ -37666,13 +37764,13 @@ error: Lexical declaration cannot appear in a single-statement context
 
 
 ✓ test/parser/suite/js/fail/c985afba4affd26b.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1e_1;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/c988e9d1ce4be150.js
@@ -37839,7 +37937,7 @@ error: Expected '}' to close switch body, but found 'result'
 error: Line terminator not allowed in regular expression literal
    |
  1 | / /
-   | ^
+   |  ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -37848,7 +37946,7 @@ error: Line terminator not allowed in regular expression literal
 error: Invalid character at start of identifier
    |
  1 | \uD800!
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -38112,8 +38210,10 @@ error: Unterminated string literal
    |
 37 |   ["islamic-umalqura", 1445, 1, "M01", "ah", 1445, "recent year"],
 38 |   ["islamic-umalqura", -6823, 1, "M01", "bh", 6824, "https:
-   |                                                    ^^^^^^^^
+   |                                                            ^
 39 |   ["persian", 1395, 1, "M01", "ap", 1395, "leap year 1395"],
+   | ^
+40 |   ["persian", 1396, 1, "M01", "ap", 1396, "common year 1396"],
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -38214,20 +38314,20 @@ error: 'instanceof' is reserved and cannot be used as an identifier
 error: Invalid character at start of identifier
    |
  1 | \u203F = 10
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
 
 ✓ test/parser/suite/js/fail/cd78a114b28a1e87.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1__1
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/cd7c94ec2bf45336.js
@@ -38619,7 +38719,7 @@ error: Optional chaining is not allowed in assignment pattern
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0\u006f0;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -38684,7 +38784,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character in identifier
    |
  1 | a\u{0}
-   | ^^
+   |   ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -38758,7 +38858,7 @@ error: Keywords cannot contain escape characters
 error: Unterminated multi-line comment
    |
  1 | /* 
-   | ^^^
+   |    ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -38851,7 +38951,7 @@ error: Expected ';' after for-loop condition, but found ')'
 error: Exponent part is missing a number
    |
  1 | 3e+
-   | ^^^
+   |    ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -38998,23 +39098,23 @@ error: Unexpected '=>'
 
 
 ✓ test/parser/suite/js/fail/d16693826dc5642d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_01_1_;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d170b0de68f13b20.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1_}
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d184090674ec7862.js
@@ -39512,13 +39612,13 @@ error: Unexpected token ';'
 
 
 ✓ test/parser/suite/js/fail/d49d3763a80ccc09.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1_)
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d4a6880bf76c7fbc.js
@@ -39543,7 +39643,7 @@ error: 'return' statement is only valid inside a function
 error: Invalid character at start of identifier
    |
  1 | \uD800\uDC00
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -39813,12 +39913,12 @@ error: 'import' is reserved and cannot be used as an identifier
    |
 
 ✓ test/parser/suite/js/fail/d5e3aad46b771d44.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1n;
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d5e73ed07b8decd5.js
@@ -39863,9 +39963,8 @@ error: Expected 'from' after import clause, but found '{'
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   #\u200C_ZWNJ;
-   | ^^^^
+   |     ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -40056,13 +40155,13 @@ error: A rest element cannot have an initializer
 
 
 ✓ test/parser/suite/js/fail/d72a211500299c91.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x1_1_, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d72c247f38001e16.js
@@ -40119,7 +40218,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 10__0123456789n;
-   | ^^^
+   |    ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -40237,13 +40336,13 @@ error: Expected 'from' after export *, but found ','
 
 
 ✓ test/parser/suite/js/fail/d8300ebab46b915e.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0o1_1_)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/d86b96e35d49e319.module.js
@@ -40278,7 +40377,7 @@ error: Expected ')' to close parameter list, but found '='
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 08a
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -40298,7 +40397,7 @@ error: Expected ',' or '}' in object, but found 'foo'
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1_1__
-   | ^^^^
+   |     ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -40336,7 +40435,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | \u200C = []
-   | ^
+   |  ^
  2 | 
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -40414,7 +40513,7 @@ error: Unexpected token '>'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 3in []
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -40439,7 +40538,7 @@ error: 'debugger' is reserved and cannot be used as a binding identifier
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 00o0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -40455,7 +40554,7 @@ error: Generators can only be declared at the top level or inside a block
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1__1;
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -40549,12 +40648,12 @@ error: Invalid assignment target
 
 
 ✓ test/parser/suite/js/fail/da31fdf1680dc2c9.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | .0_e1
-   | ^^^
+   |    ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/da3e665b276b2a02.js
@@ -40711,13 +40810,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/db59c56d2018118d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_E1;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/db5c3523e77d11b5.js
@@ -40884,7 +40983,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Unterminated string literal
    |
  1 | (')
-   |  ^^
+   |    ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -40960,7 +41059,7 @@ error: Getter must have no parameters
 error: Octal literal must contain at least one octal digit
    |
  1 | 0o;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -40998,7 +41097,7 @@ error: Unexpected token '>'
 error: Octal literal must contain at least one octal digit
    |
  1 | 0O
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -41052,7 +41151,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1_1__, 0
-   | ^^^^
+   |     ^
  2 | 
    |
    = help: Try removing one of the consecutive underscores here
@@ -41082,7 +41181,7 @@ error: Unexpected token '='
 error: Octal literal must contain at least one octal digit
    |
  1 | 0o9n;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one octal digit (0-7) here after '0o'
 
@@ -41097,11 +41196,9 @@ error: 'else' is reserved and cannot be used as an identifier
 ✓ test/parser/suite/js/fail/dd430cb9f8d82e68.js
 error: Invalid character at start of identifier
    |
- 1 | class Foo {
  2 |   #p = x
-   |         ^
  3 |   #[m] = 1
-   | ^^^
+   |    ^
  4 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -41148,8 +41245,9 @@ error: 'void' is reserved and cannot be used as a binding identifier
 error: Line terminator not allowed in regular expression literal
    |
  1 | var x = /
-   |         ^
+   |          ^
  2 | /
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -41424,7 +41522,7 @@ error: Rest element must be the last property
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 01_0;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -41433,7 +41531,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Invalid character in identifier
    |
  1 | var\u2029x;
-   | ^^^^
+   |     ^
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
 
@@ -41590,8 +41688,9 @@ error: A rest element cannot have an initializer
 error: Unterminated string literal
    |
  1 | "
-   | ^
+   |  ^
  2 | "
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -41641,7 +41740,7 @@ error: Invalid character at start of identifier
    |
  6 | m() {
  7 |     this.f().# x;
-   |              ^
+   |               ^
  8 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -41810,7 +41909,7 @@ error: Rest element must be the last element
 error: Unterminated string literal
    |
  1 | var str = ''';
-   |             ^^
+   |               ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -41871,13 +41970,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/e0dc5b3cc72830c6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1_]
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e0dd6d8d5e87c01a.js
@@ -41946,8 +42045,10 @@ error: Line terminator not allowed in regular expression literal
    |
 14 | assert(/\|/u.test("|"), "IdentityEscape in AtomEscape: /\\|/");
 15 | assert(/\
-   |        ^
+   |          ^
 16 | assert(/[\^]/u.test("^"), "IdentityEscape in ClassEscape: /[\\^]/");
+   | ^
+17 | assert(/[\$]/u.test("$"), "IdentityEscape in ClassEscape: /[\\$]/");
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -42136,8 +42237,9 @@ error: Unterminated string literal
    |
  5 | if (new String(__obj).slice(  undefined, __obj) !== "") {
  6 |   throw new Test262Error('#1: __obj = {valueOf:function(){}, toString:void 0}; new String(__obj).slice(
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                                                                        ^
  7 | }
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -42213,7 +42315,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Unterminated multi-line comment
    |
  1 | /*hello  *
-   | ^^^^^^^^^^
+   |           ^
    |
    = help: Try adding the closing delimiter (*/) here to complete the comment
 
@@ -42233,9 +42335,8 @@ error: 'import' keyword is not allowed here
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   # x;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -42251,13 +42352,13 @@ error: 'yield' is reserved in a generator context and cannot be used as an ident
    |
 
 ✓ test/parser/suite/js/fail/e31e6387be704159.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {0o_11}
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e3692dfb17932c20.js
@@ -42348,6 +42449,16 @@ error: Expected 'while' after do statement body, but found 'var'
    |             ^^^
    |
 
+✓ test/parser/suite/js/fail/e3d8bc5a1faa9260.js
+error: Unexpected token ':'
+   |
+ 1 | ::import.defer("foo")
+   | ^
+ 2 | 
+   |
+   = help: Expected an expression
+
+
 ✓ test/parser/suite/js/fail/e3e58d5cff520c20.js
 error: Rest element must be the last element
    |
@@ -42386,7 +42497,7 @@ error: Invalid character at start of identifier
    |
  1 | var C = class {
  2 |   static # x;
-   |         ^^
+   |           ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -42491,13 +42602,13 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/e49903629603e39f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1.1_e1)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e49a9e234652b08a.js
@@ -42538,7 +42649,7 @@ error: Unexpected token ',' as property key
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_0123456789n;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -42592,13 +42703,13 @@ error: Unexpected token '>'
 
 
 ✓ test/parser/suite/js/fail/e52069a148773c0f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1._1_1}
-   |  ^^^
+   |     ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e52b59340438557a.js
@@ -42749,13 +42860,13 @@ error: Invalid element in assignment pattern
 
 
 ✓ test/parser/suite/js/fail/e5f152dd5396b0c5.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0x_1__1;
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e5fabf7fc4ae5dea.js
@@ -42768,13 +42879,13 @@ error: Rest element is not allowed in parenthesized expression
 
 
 ✓ test/parser/suite/js/fail/e60d0d56af9f446a.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (0b_01_1_)
-   |  ^^
+   |    ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/e6101c598bc6021e.js
@@ -42819,7 +42930,7 @@ error: Unexpected token '>'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 07_0n;
-   | ^^
+   |   ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -42837,8 +42948,9 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Line terminator not allowed in regular expression literal
    |
  1 | /\
-   | ^
+   |   ^
  2 | /
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 
@@ -42954,7 +43066,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | var x = /[P QR]/\\u0067
-   |                 ^
+   |                  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -43058,7 +43170,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: The 'u' and 'v' regular expression flags cannot be used together
    |
  1 | /a/vu;
-   | ^
+   |      ^
  2 | 
    |
    = help: The 'u' (unicode) and 'v' (unicodeSets) flags are mutually exclusive; use one or the other
@@ -43285,7 +43397,7 @@ error: 'import' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | \u_0061;
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -43667,7 +43779,7 @@ error: Invalid character at start of identifier
    |
  2 |   method() {
  3 |     foo().\u0023field;
-   |           ^
+   |            ^
  4 |   }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -43793,7 +43905,7 @@ error: Expected ')' to close parameter list, but found '='
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 012348n;
-   | ^^^^^^
+   |       ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -43988,12 +44100,12 @@ error: Invalid element in assignment pattern
 
 
 ✓ test/parser/suite/js/fail/ec914e65fab6e94f.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10._
-   | ^^
+   |   ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/eca3254326c03740.js
@@ -44037,9 +44149,8 @@ error: Optional chaining is not allowed in assignment pattern
 error: Invalid character at start of identifier
    |
  1 | class Foo {
-   |            ^
  2 |   #2x = y
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -44049,7 +44160,7 @@ error: Invalid character at start of identifier
 error: Invalid character at start of identifier
    |
  1 | \u00281\u0029;
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -44121,13 +44232,13 @@ error: Unexpected token '...'
 
 
 ✓ test/parser/suite/js/fail/ed4838c791b4a074.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1.1_e1}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ed526acd72c56f03.js
@@ -44207,9 +44318,8 @@ error: Unexpected token ')'
 error: Invalid character at start of identifier
    |
  1 | class Spaces {
-   |               ^
  2 |   #  wrongSpaces;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -44255,7 +44365,7 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character in identifier
    |
  1 | \u2163\u2161\u200A
-   | ^^^^^^^^^^^^^
+   |              ^
  2 | 
    |
    = help: Try using a valid identifier character here (letters, digits, underscore, or dollar sign)
@@ -44550,7 +44660,7 @@ error: Keywords cannot contain escape characters
 error: Duplicate regular expression flag
    |
  1 | /./ii
-   | ^
+   |     ^
    |
    = help: Remove the duplicate flag; each flag can only appear once
 
@@ -44680,7 +44790,7 @@ error: Unexpected token '=>' in expression
 error: Invalid Unicode escape sequence
    |
  1 | \u113
-   | ^
+   |  ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -44742,7 +44852,7 @@ error: Rest parameter may not have a trailing comma
 error: Unterminated string literal
    |
  1 | '\03
-   | ^^^^
+   |     ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -44751,7 +44861,7 @@ error: Unterminated string literal
 error: Unterminated template literal
    |
  1 | `test
-   | ^^^^^
+   |      ^
    |
    = help: Try adding a closing backtick (`) here to complete the template
 
@@ -44809,7 +44919,7 @@ error: Rest element must be the last element
 error: Unterminated string literal
    |
  1 | '\
-   | ^^
+   |   ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -44843,13 +44953,13 @@ error: Empty parentheses are only valid as arrow function parameters
    |
 
 ✓ test/parser/suite/js/fail/f0ba2b4dfcb48203.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1e_1, 0
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f0c0960759be131a.js
@@ -44901,9 +45011,8 @@ error: Rest parameter must be the last parameter
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   \u200C_ZWNJ;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -44954,8 +45063,10 @@ error: 'for await' is only valid in async functions or modules
 error: Unterminated string literal
    |
  1 | if (decodeURIComponent("http:
-   |                        ^^^^^^
+   |                              ^
  2 |   throw new Test262Error('#1: http:
+   | ^
+ 3 | }
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -45206,7 +45317,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   static # x = 1;
-   |         ^^
+   |           ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -45220,13 +45331,13 @@ error: Async functions can only be declared at the top level or inside a block
    |
 
 ✓ test/parser/suite/js/fail/f2fc6dc8a9373708.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0b_01_1_, 0
-   | ^^
+   |   ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f2feb3a280f57b2d.js
@@ -45302,13 +45413,13 @@ error: Expected identifier or string literal, but found '%'
    |
 
 ✓ test/parser/suite/js/fail/f38a4391b7f48ec5.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [0o1_1_]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f38bde59e86aaf86.js
@@ -45345,9 +45456,8 @@ error: 'default' is reserved and cannot be used as an identifier
 error: Invalid character at start of identifier
    |
  1 | var C = class {
-   |                ^
  2 |   \u200D_ZWJ;
-   | ^^^
+   |    ^
  3 | };
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -45437,13 +45547,13 @@ error: Expected ',' or ']' in array, but found 'foo'
 
 
 ✓ test/parser/suite/js/fail/f462014fd8999846.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1.1E_1}
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f479679ba0c7f690.js
@@ -45674,7 +45784,7 @@ error: Expected ';' after for-loop init, but found 'void'
 error: Binary literal must contain at least one binary digit
    |
  1 | 0b;
-   | ^^
+   |   ^
    |
    = help: Try adding at least one binary digit (0 or 1) here after '0b'
 
@@ -45815,9 +45925,8 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 error: Invalid character at start of identifier
    |
  1 | class C {
-   |          ^
  2 |   \u200C_ZWNJ;
-   | ^^^
+   |    ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -45827,7 +45936,7 @@ error: Invalid character at start of identifier
 error: Invalid character at start of identifier
    |
  1 | \u003B;
-   | ^
+   |  ^
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
 
@@ -45847,7 +45956,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 1\u005F0123456789
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -45869,13 +45978,13 @@ error: 'while' is reserved and cannot be used as a binding identifier
    |
 
 ✓ test/parser/suite/js/fail/f6a90eddbeb7cb83.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1e_1
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f6b5c3a77e09eb15.js
@@ -45917,7 +46026,7 @@ error: 'else' is reserved and cannot be used as an identifier
 error: Invalid Unicode escape sequence
    |
  1 | a\u12
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -46042,7 +46151,7 @@ error: Keywords cannot contain escape characters
 error: Exponent part is missing a number
    |
  1 | 3ea
-   | ^^
+   |   ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -46182,7 +46291,7 @@ error: Expected '(' for getter/setter definition, but found ';'
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_7;
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -46191,7 +46300,7 @@ error: Identifier cannot immediately follow a numeric literal
 error: Invalid Unicode escape sequence
    |
  1 | "\u{110000}"
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -46260,7 +46369,7 @@ error: Unterminated string literal
    |
 11 | }
 12 | assertToStringOrNativeFunction(f, "function\n
-   |                                  ^^^^^^^^^^^^
+   |                                              ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -46349,12 +46458,12 @@ error: Rest element must be the last element
 
 
 ✓ test/parser/suite/js/fail/f946834303370024.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 10.0_e1
-   | ^^^^^
+   |      ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/f9485f1ab4f6f34f.js
@@ -46538,13 +46647,13 @@ error: Using declaration cannot appear in the bare case statement.
 
 
 ✓ test/parser/suite/js/fail/fa3c8cf8da81aed6.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 1_1.1_e1;
-   | ^^^^^^
+   |       ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/fa3fa1da78e8e8ab.js
@@ -46655,7 +46764,7 @@ error: Invalid character at start of identifier
    |
  1 | class C {
  2 |   async * # m() {}
-   |          ^^
+   |            ^
  3 | }
    |
    = help: Try starting the identifier here with a letter (a-z, A-Z), underscore (_), or dollar sign ($)
@@ -46676,7 +46785,7 @@ error: A rest element cannot have an initializer
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 0_8
-   | ^
+   |  ^
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -46772,8 +46881,10 @@ error: Unterminated string literal
    |
 25 | const additionalCases = [
 26 |   ["indian", 2000, 12, 31, "https:
-   |                           ^^^^^^^^
+   |                                   ^
 27 | ];
+   | ^
+28 | for (const [calendar, isoYear, isoMonth, isoDay, descr] of additionalCases) {
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -46834,7 +46945,7 @@ error: Invalid element in assignment pattern
 error: Invalid Unicode escape sequence
    |
  1 | \u{FFZ}
-   | ^
+   |  ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -46929,7 +47040,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 error: Numeric literal cannot contain consecutive separators
    |
  1 | 1__0123456789n;
-   | ^^
+   |   ^
    |
    = help: Try removing one of the consecutive underscores here
 
@@ -47038,13 +47149,13 @@ error: 'import' keyword is not allowed here
 
 
 ✓ test/parser/suite/js/fail/fc5d332342e57a90.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | (1_1.1E_1)
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/fc75a023944da475.js
@@ -47079,7 +47190,7 @@ error: 'return' statement is only valid inside a function
 error: Invalid Unicode escape sequence
    |
  1 | "\u0";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
@@ -47132,6 +47243,7 @@ error: 'false' is reserved and cannot be used as a binding identifier
    |     ^^^^^
    |
 
+✗ test/parser/suite/js/fail/fd053da2d16d1cc1.js (expected error, but parsed successfully)
 ✓ test/parser/suite/js/fail/fd09d4a8517f0577.js
 error: Unexpected token '>'
    |
@@ -47227,8 +47339,10 @@ error: Unterminated string literal
    |
 37 |   ["islamic-umalqura", 1445, 1, "M01", 1, "ah", 1445, "recent year"],
 38 |   ["islamic-umalqura", -6823, 1, "M01", 1, "bh", 6824, "https:
-   |                                                       ^^^^^^^^
+   |                                                               ^
 39 |   ["persian", 1395, 1, "M01", 1, "ap", 1395, "leap year 1395"],
+   | ^
+40 |   ["persian", 1396, 1, "M01", 1, "ap", 1396, "common year 1396"],
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -47261,12 +47375,12 @@ error: Parenthesized expression in assignment pattern must be a simple assignmen
 
 
 ✓ test/parser/suite/js/fail/fdd7f1c5380dab75.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | 0o0_
-   | ^^^^
+   |     ^
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/fdeb942fe9ba2cdd.js
@@ -47364,7 +47478,7 @@ error: A rest element cannot have an initializer
 error: Exponent part is missing a number
    |
  1 | 1.e+
-   | ^^^^
+   |     ^
    |
    = help: Try adding digits here after the exponent (e.g., e10, e-5, E+2)
 
@@ -47505,13 +47619,13 @@ error: Unexpected token ')'
 
 
 ✓ test/parser/suite/js/fail/fed97158c12b294d.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | {1_1_.1_1}
-   |  ^^^^
+   |      ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/fedd5d306462cde4.module.js
@@ -47559,7 +47673,7 @@ error: Rest element must be the last property
 error: Invalid Unicode escape sequence
    |
  1 | a\u111z
-   | ^^
+   |   ^
    |
    = help: Try using \uHHHH (4 hex digits) or \u{HHHHHH} (1-6 hex digits) here
 
@@ -47584,13 +47698,13 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
 
 
 ✓ test/parser/suite/js/fail/ff14bff7d44dbd10.js
-error: Numeric separator cannot appear at the end of a numeric literal
+error: Numeric separator is only allowed between two digits
    |
  1 | [1_1.1_E1]
-   |  ^^^^^^
+   |        ^
  2 | 
    |
-   = help: Try removing the trailing underscore here or adding more digits after it
+   = help: Try placing the separator between two digits, or removing it
 
 
 ✓ test/parser/suite/js/fail/ff3904cb055fa6dc.js
@@ -47657,8 +47771,9 @@ error: Unterminated string literal
    |
  2 | var AsyncFunction = f.constructor;
  3 | var g = AsyncFunction("a", "  b, c
-   |                           ^^^^^^^^
+   |                                   ^
  4 | assertToStringOrNativeFunction(g, "async function anonymous(a,  b, c
+   | ^
    |
    = help: Try adding a closing quote here to complete the string
 
@@ -47678,7 +47793,7 @@ error: Rest element must be the last element
 error: Invalid hexadecimal escape sequence
    |
  1 | "\x";
-   | ^^
+   |   ^
  2 | 
    |
    = help: Try adding two hexadecimal digits here (e.g., \x41 for 'A')

--- a/test/parser/results/js_pass.txt
+++ b/test/parser/results/js_pass.txt
@@ -1,6 +1,6 @@
 test/parser/suite/js/pass
 =========================
-Passed:       38725/38725 (100.00%)
+Passed:       38727/38727 (100.00%)
 Failed:       0
 AST mismatch: 0/38725
 
@@ -22953,6 +22953,7 @@ AST mismatch: 0/38725
 ✓ test/parser/suite/js/pass/98de9c31a633e2ed.js
 ✓ test/parser/suite/js/pass/98df58b0c40fac90.js
 ✓ test/parser/suite/js/pass/98e23c0737a5f451.js
+✓ test/parser/suite/js/pass/98e39930dc0e4640.js
 ✓ test/parser/suite/js/pass/98e4d103753a83d9.js
 ✓ test/parser/suite/js/pass/98e5346093f8ef68.js
 ✓ test/parser/suite/js/pass/98e7511664aff0ff.js
@@ -25972,6 +25973,7 @@ AST mismatch: 0/38725
 ✓ test/parser/suite/js/pass/ac96a475aee26d2b.js
 ✓ test/parser/suite/js/pass/ac96b1c0f9745aa8.js
 ✓ test/parser/suite/js/pass/ac99997d9abf4765.js
+✓ test/parser/suite/js/pass/ac9bb9045371642f.js
 ✓ test/parser/suite/js/pass/ac9c6eb841745444.js
 ✓ test/parser/suite/js/pass/ac9cc6e563b1c940.js
 ✓ test/parser/suite/js/pass/ac9d55fa5459a13b.js

--- a/test/parser/results/jsx_fail.txt
+++ b/test/parser/results/jsx_fail.txt
@@ -87,7 +87,6 @@ error: Expected JSX element name, but found '>'
 error: Unterminated string literal
    |
  1 | <foo bar="
-   |          ^
  2 | 
    | ^
    |
@@ -167,8 +166,9 @@ error: Expected '>' to close JSX opening element, but found '.'
 error: Line terminator not allowed in regular expression literal
    |
  1 | var x = <div>one</div><div>two</div>;
-   |                                ^
+   |                                      ^
  2 | 
+   | ^
    |
    = help: Try removing the line break here or escaping it within the regex pattern
 

--- a/test/parser/results/test_parser_misc_js.txt
+++ b/test/parser/results/test_parser_misc_js.txt
@@ -162,7 +162,7 @@ error: 'import defer' only supports a namespace import
 error: Identifier cannot immediately follow a numeric literal
    |
  1 | 012_7
-   | ^^^
+   |    ^
  2 | 
    |
    = help: Try adding whitespace here between the number and identifier


### PR DESCRIPTION
A lexical diagnostic spanned from the end of the previous token to the lexer cursor, so it always covered the whitespace and comments between the two. "let x = 0x_ab" underlined " 0x" instead of the misplaced "_".

A lexical diagnostic now underlines the single byte at the lexer cursor where the scan stopped, zero-width at the end of input: "0x_ab" underlines the "_", and an unterminated string reports at the end of input. `reportLexicalError` owns the rule and is the one reporting path for lexer errors: the three call sites that catch them during a re-scan (regex and template continuations) report through it too, instead of re-deriving message, help, and span.

The numeric separator message also claimed the separator was "at the end" of the literal, wrong for "0x_1" and "1._5". All misuse positions now share one generic message, matching tsc, babel, and swc.