### PR TITLE
fix(playground): type over auto-closed brackets and quotes

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -962,6 +962,21 @@ document.addEventListener("selectionchange", () => {
 codeView.addEventListener("click", () => mapCaret(true, true));
 codeView.addEventListener("blur", removeHit);
 
+// CodeJar's addClosing inserts the closer after the caret but never types over
+// it, so typing the matching closer would duplicate the character. Move the
+// caret instead when the next character already is that closer.
+const CLOSERS = ")]}'\"";
+codeView.addEventListener("keydown", (e) => {
+  if (e.isComposing || e.metaKey || e.ctrlKey || e.altKey) return;
+  if (!CLOSERS.includes(e.key)) return;
+  const sel = window.getSelection();
+  if (!sel || !sel.isCollapsed) return;
+  const offset = caretOffset();
+  if (offset == null || codeView.textContent[offset] !== e.key) return;
+  e.preventDefault();
+  sel.modify("move", "forward", "character");
+});
+
 let tipFrame;
 codeView.addEventListener("mousemove", (e) => {
   const { clientX, clientY } = e;


### PR DESCRIPTION
## Problem

The playground editor (CodeJar) auto-closes `([{'"` via its built-in `addClosing` option, but it has no type-over behavior: when the character right after the caret is already the auto-inserted closer, typing that closer again inserts a duplicate. Typing `(` then `)` produces `())` instead of `()`, which is annoying during continuous typing.

## Solution

Add a `keydown` handler on the editor that intercepts the closing characters `)]}'"` (the same set CodeJar auto-closes): when the caret is collapsed and the character immediately after it is the same closer, `preventDefault()` and move the caret over it (`Selection.modify("move", "forward", "character")`). Otherwise the default insertion is left untouched, so inserting an extra closer or replacing a selection still works.

This plays nicely with CodeJar internals: its history recording deduplicates unchanged records, and the keyup-side `prev !== toString()` check skips re-highlighting, so a type-over causes no extra render and no empty undo step.

## Verification

Manually verified in the playground with real keystrokes:

- `(` then `)` → `()` (pair inserted, closer typed over)
- `[` then `]` → `[]`
- `"` then `"` → `""`
- typing `)` / `]` when no matching closer follows still inserts it normally
