### PR TITLE
fix(codegen): preserve shadowed undefined references

### DIFF
--- a/docs/content/parser/codegen.smd
+++ b/docs/content/parser/codegen.smd
@@ -242,7 +242,6 @@ defer result.deinit(allocator);
 The substitutions.
 
 - `true` / `false` → `!0` / `!1`
-- `undefined` → `void 0` (in expression position)
 - `Infinity` → `1/0`
 - numeric literals shortened to their shortest form (`1000000` → `1e6`, `0.5` → `.5`, etc.)
 - `obj["foo"]` → `obj.foo` when the key is a valid identifier

--- a/npm/yuku-codegen/README.md
+++ b/npm/yuku-codegen/README.md
@@ -96,7 +96,6 @@ const { code } = generate(program, { minify: { syntax: true } });
 The `syntax` rewrites:
 
 - `true` and `false` rewrite to `!0` and `!1`.
-- `undefined` rewrites to `void 0` (in expression position).
 - `Infinity` rewrites to `1/0`.
 - Numeric literals shorten to their shortest form (`1000000` becomes `1e6`, `0.5` becomes `.5`).
 - `obj["foo"]` rewrites to `obj.foo` when the key is a valid identifier.

--- a/src/parser/codegen/printer.zig
+++ b/src/parser/codegen/printer.zig
@@ -444,11 +444,10 @@ const Printer = struct {
             .ts_instantiation_expression,
             => Precedence.Call,
             .boolean_literal => if (self.options.minify) Precedence.Unary else Precedence.Grouping,
-            // minify rewrites `undefined` and `Infinity`
+            // minify rewrites `Infinity`
             .identifier_reference => |id| blk: {
                 if (!self.options.minify or self.in_assign_target) break :blk Precedence.Grouping;
                 const s = self.tree.string(id.name);
-                if (std.mem.eql(u8, s, "undefined")) break :blk Precedence.Unary;
                 if (std.mem.eql(u8, s, "Infinity")) break :blk Precedence.Multiplicative;
                 break :blk Precedence.Grouping;
             },
@@ -1565,7 +1564,6 @@ const Printer = struct {
         if (self.options.minify) {
             if (!self.in_assign_target) {
                 const name = self.tree.string(id.name);
-                if (std.mem.eql(u8, name, "undefined")) return self.writeStr("void 0");
                 if (std.mem.eql(u8, name, "Infinity")) return self.writeStr("1/0");
             }
         }
@@ -2161,7 +2159,7 @@ const Printer = struct {
     }
 
     /// emits `idx` as a TS entity name (Identifier | QualifiedName | this |
-    /// ImportType). Suppresses `undefined`/`Infinity` rewrites that the
+    /// ImportType). Suppresses `Infinity` rewrites that the
     /// expression-context emitter applies, since type queries and type
     /// references require a bare entity name.
     fn emitEntityName(self: *Self, idx: NodeIndex) Error!void {
@@ -2638,8 +2636,8 @@ const Printer = struct {
         if (d.declare) try self.writeStr("declare ");
         try self.writeStr(d.kind.toString());
         try self.writeByte(' ');
-        // route through emitEntityName so the minify-mode `undefined ->
-        // void 0` rewrite never fires on a declaration name.
+        // route through emitEntityName so the minify-mode `Infinity -> 1/0`
+        // rewrite never fires on a declaration name
         try self.emitEntityName(d.id);
         if (d.body != .null) {
             try self.space();

--- a/test/codegen/generate.test.ts
+++ b/test/codegen/generate.test.ts
@@ -7,7 +7,7 @@ test("strip and minify compose in a single call", () => {
       strip: true,
       minify: true,
     }),
-  ).toMatchInlineSnapshot(`"const x=1e6;if(!0){obj.foo=void 0}"`);
+  ).toMatchInlineSnapshot(`"const x=1e6;if(!0){obj.foo=undefined}"`);
 });
 
 test("minify: true forces maximum minification over format and quotes", () => {

--- a/test/codegen/minify.test.ts
+++ b/test/codegen/minify.test.ts
@@ -28,6 +28,12 @@ const g = 1234.5;`,
   );
 });
 
+test("keeps references to a shadowed undefined binding", () => {
+  expect(gen(`function f(undefined) { return undefined; }`, MINIFY)).toMatchInlineSnapshot(
+    `"function f(undefined){return undefined}"`,
+  );
+});
+
 test("escapes script-close sequences in strings and templates", () => {
   expect(
     gen(


### PR DESCRIPTION
## Summary

- Preserve `undefined` identifier references during syntax minification.
- Remove the unsafe `undefined -> void 0` rewrite from the documentation.
- Add regression coverage for a parameter that shadows `undefined`.

The code generator receives an AST without binding-resolution data, so rewriting an identifier based only on its spelling can change runtime behavior. Keeping the reference intact preserves semantics until this optimization can be performed by a scope-aware stage.

Fixes #191.

## Tests

- `zig build test`
- `bun run test:codegen`
- `bun run typecheck`
